### PR TITLE
Some small changes

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -17,15 +17,11 @@ func (p records) Len() int {
 }
 
 func (p records) Less(i, j int) bool {
-	return p[i].(*record).Less(p[j])
+	return p[i].(*record).key < p[j].(*record).key
 }
 
 func (p records) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
-}
-
-func (self *record) Less(o interface{}) bool {
-	return self.key < o.(*record).key
 }
 
 func LessThanByKey(a, b interface{}) bool {
@@ -46,6 +42,7 @@ func LessThanByKeyByOrder(a, b interface{}) bool {
 }
 
 func makeVector(size int, shape string) (v records) {
+	v = make(records, 0, size)
 	switch shape {
 
 	case "xor":

--- a/timsort.go
+++ b/timsort.go
@@ -373,10 +373,8 @@ func countRunAndMakeAscending(a []interface{}, lo, hi int, lt LessThan) (int, er
 func reverseRange(a []interface{}, lo, hi int) {
 	hi--
 	for lo < hi {
-		t := a[lo]
-		a[lo] = a[hi]
+		a[lo], a[hi] = a[hi], a[lo]
 		lo++
-		a[hi] = t
 		hi--
 	}
 }


### PR DESCRIPTION
1. In makeVector of bench_test, I added a line to allocation a slice for v before appending it, this avoids small slices allocated. Without this change, I can't run all benchmark successfully under  default go configs.
2. records.Less is modified to use less function call, which makes the comparison more fair.
3. Some lines are rewrite in go idiomic style.(exchange values)

David
