### PR TITLE
Moving to Generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 coverage.txt
 
+*bench*.txt

--- a/v3/bench_test.go
+++ b/v3/bench_test.go
@@ -10,10 +10,10 @@ type record struct {
 	key, order int
 }
 
-type records []interface{}
+type records []record
 
-func LessThanByKey(a, b interface{}) bool {
-	return a.(*record).key < b.(*record).key
+func LessThanByKey(a, b record) bool {
+	return a.key < b.key
 }
 
 type RecordSlice []record
@@ -36,24 +36,24 @@ func makeVector(size int, shape string) (v records) {
 
 	case "xor":
 		for i := 0; i < size; i++ {
-			v[i] = &record{0xff & (i ^ 0xab), i}
+			v[i] = record{0xff & (i ^ 0xab), i}
 		}
 
 	case "sorted":
 		for i := 0; i < size; i++ {
-			v[i] = &record{i, i}
+			v[i] = record{i, i}
 		}
 
 	case "revsorted":
 		for i := 0; i < size; i++ {
-			v[i] = &record{size - i, i}
+			v[i] = record{size - i, i}
 		}
 
 	case "random":
 		rand.Seed(1)
 
 		for i := 0; i < size; i++ {
-			v[i] = &record{rand.Int(), i}
+			v[i] = record{rand.Int(), i}
 		}
 
 	default:

--- a/v3/bench_test.go
+++ b/v3/bench_test.go
@@ -1,0 +1,277 @@
+package timsort
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+type record struct {
+	key, order int
+}
+
+type records []interface{}
+
+func LessThanByKey(a, b interface{}) bool {
+	return a.(*record).key < b.(*record).key
+}
+
+type RecordSlice []record
+
+func (s *RecordSlice) Len() int {
+	return len(*s)
+}
+
+func (s *RecordSlice) Swap(i, j int) {
+	(*s)[i], (*s)[j] = (*s)[j], (*s)[i]
+}
+
+func (s *RecordSlice) Less(i, j int) bool {
+	return (*s)[i].key < (*s)[j].key
+}
+
+func makeVector(size int, shape string) (v records) {
+	v = make(records, size)
+	switch shape {
+
+	case "xor":
+		for i := 0; i < size; i++ {
+			v[i] = &record{0xff & (i ^ 0xab), i}
+		}
+
+	case "sorted":
+		for i := 0; i < size; i++ {
+			v[i] = &record{i, i}
+		}
+
+	case "revsorted":
+		for i := 0; i < size; i++ {
+			v[i] = &record{size - i, i}
+		}
+
+	case "random":
+		rand.Seed(1)
+
+		for i := 0; i < size; i++ {
+			v[i] = &record{rand.Int(), i}
+		}
+
+	default:
+		panic(shape)
+	}
+
+	return v
+}
+
+func makeRecords(size int, shape string) (v RecordSlice) {
+	v = make(RecordSlice, size)
+	switch shape {
+
+	case "xor":
+		for i := 0; i < size; i++ {
+			v[i] = record{0xff & (i ^ 0xab), i}
+		}
+
+	case "sorted":
+		for i := 0; i < size; i++ {
+			v[i] = record{i, i}
+		}
+
+	case "revsorted":
+		for i := 0; i < size; i++ {
+			v[i] = record{size - i, i}
+		}
+
+	case "random":
+		rand.Seed(1)
+
+		for i := 0; i < size; i++ {
+			v[i] = record{rand.Int(), i}
+		}
+
+	default:
+		panic(shape)
+	}
+
+	return v
+}
+
+func benchmarkTimsort(b *testing.B, size int, shape string) {
+	b.StopTimer()
+
+	for j := 0; j < b.N; j++ {
+		v := makeVector(size, shape)
+
+		b.StartTimer()
+		Sort(v, LessThanByKey)
+		b.StopTimer()
+	}
+}
+
+func benchmarkTimsortInterface(b *testing.B, size int, shape string) {
+	b.StopTimer()
+
+	for j := 0; j < b.N; j++ {
+		v := makeRecords(size, shape)
+
+		b.StartTimer()
+		TimSort(&v)
+		b.StopTimer()
+	}
+}
+
+func benchmarkStandardSort(b *testing.B, size int, shape string) {
+	b.StopTimer()
+
+	for j := 0; j < b.N; j++ {
+		v := makeRecords(size, shape)
+
+		b.StartTimer()
+		sort.Stable(&v)
+		b.StopTimer()
+	}
+}
+
+func BenchmarkTimsortXor100(b *testing.B) {
+	benchmarkTimsort(b, 100, "xor")
+}
+
+func BenchmarkTimsortInterXor100(b *testing.B) {
+	benchmarkTimsortInterface(b, 100, "xor")
+}
+
+func BenchmarkStandardSortXor100(b *testing.B) {
+	benchmarkStandardSort(b, 100, "xor")
+}
+
+func BenchmarkTimsortSorted100(b *testing.B) {
+	benchmarkTimsort(b, 100, "sorted")
+}
+
+func BenchmarkTimsortInterSorted100(b *testing.B) {
+	benchmarkTimsortInterface(b, 100, "sorted")
+}
+
+func BenchmarkStandardSortSorted100(b *testing.B) {
+	benchmarkStandardSort(b, 100, "sorted")
+}
+
+func BenchmarkTimsortRevSorted100(b *testing.B) {
+	benchmarkTimsort(b, 100, "revsorted")
+}
+
+func BenchmarkTimsortInterRevSorted100(b *testing.B) {
+	benchmarkTimsortInterface(b, 100, "revsorted")
+}
+
+func BenchmarkStandardSortRevSorted100(b *testing.B) {
+	benchmarkStandardSort(b, 100, "revsorted")
+}
+
+func BenchmarkTimsortRandom100(b *testing.B) {
+	benchmarkTimsort(b, 100, "random")
+}
+
+func BenchmarkTimsortInterRandom100(b *testing.B) {
+	benchmarkTimsortInterface(b, 100, "random")
+}
+
+func BenchmarkStandardSortRandom100(b *testing.B) {
+	benchmarkStandardSort(b, 100, "random")
+}
+
+func BenchmarkTimsortXor1K(b *testing.B) {
+	benchmarkTimsort(b, 1024, "xor")
+}
+
+func BenchmarkTimsortInterXor1K(b *testing.B) {
+	benchmarkTimsortInterface(b, 1024, "xor")
+}
+
+func BenchmarkStandardSortXor1K(b *testing.B) {
+	benchmarkStandardSort(b, 1024, "xor")
+}
+
+func BenchmarkTimsortSorted1K(b *testing.B) {
+	benchmarkTimsort(b, 1024, "sorted")
+}
+
+func BenchmarkTimsortInterSorted1K(b *testing.B) {
+	benchmarkTimsortInterface(b, 1024, "sorted")
+}
+
+func BenchmarkStandardSortSorted1K(b *testing.B) {
+	benchmarkStandardSort(b, 1024, "sorted")
+}
+
+func BenchmarkTimsortRevSorted1K(b *testing.B) {
+	benchmarkTimsort(b, 1024, "revsorted")
+}
+
+func BenchmarkTimsortInterRevSorted1K(b *testing.B) {
+	benchmarkTimsortInterface(b, 1024, "revsorted")
+}
+
+func BenchmarkStandardSortRevSorted1K(b *testing.B) {
+	benchmarkStandardSort(b, 1024, "revsorted")
+}
+
+func BenchmarkTimsortRandom1K(b *testing.B) {
+	benchmarkTimsort(b, 1024, "random")
+}
+
+func BenchmarkTimsortInterRandom1K(b *testing.B) {
+	benchmarkTimsortInterface(b, 1024, "random")
+}
+
+func BenchmarkStandardSortRandom1K(b *testing.B) {
+	benchmarkStandardSort(b, 1024, "random")
+}
+
+func BenchmarkTimsortXor1M(b *testing.B) {
+	benchmarkTimsort(b, 1024*1024, "xor")
+}
+
+func BenchmarkTimsortInterXor1M(b *testing.B) {
+	benchmarkTimsortInterface(b, 1024*1024, "xor")
+}
+
+func BenchmarkStandardSortXor1M(b *testing.B) {
+	benchmarkStandardSort(b, 1024*1024, "xor")
+}
+
+func BenchmarkTimsortSorted1M(b *testing.B) {
+	benchmarkTimsort(b, 1024*1024, "sorted")
+}
+
+func BenchmarkTimsortInterSorted1M(b *testing.B) {
+	benchmarkTimsortInterface(b, 1024*1024, "sorted")
+}
+
+func BenchmarkStandardSortSorted1M(b *testing.B) {
+	benchmarkStandardSort(b, 1024*1024, "sorted")
+}
+
+func BenchmarkTimsortRevSorted1M(b *testing.B) {
+	benchmarkTimsort(b, 1024*1024, "revsorted")
+}
+
+func BenchmarkTimsortInterRevSorted1M(b *testing.B) {
+	benchmarkTimsortInterface(b, 1024*1024, "revsorted")
+}
+
+func BenchmarkStandardSortRevSorted1M(b *testing.B) {
+	benchmarkStandardSort(b, 1024*1024, "revsorted")
+}
+
+func BenchmarkTimsortRandom1M(b *testing.B) {
+	benchmarkTimsort(b, 1024*1024, "random")
+}
+
+func BenchmarkTimsortInterRandom1M(b *testing.B) {
+	benchmarkTimsortInterface(b, 1024*1024, "random")
+}
+
+func BenchmarkStandardSortRandom1M(b *testing.B) {
+	benchmarkStandardSort(b, 1024*1024, "random")
+}

--- a/v3/benchint_test.go
+++ b/v3/benchint_test.go
@@ -1,0 +1,170 @@
+package timsort
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+type ints []int
+
+func (p *ints) Len() int           { return len(*p) }
+func (p *ints) Less(i, j int) bool { return (*p)[i] < (*p)[j] }
+func (p *ints) Swap(i, j int)      { (*p)[i], (*p)[j] = (*p)[j], (*p)[i] }
+
+func LessThanInt(a, b int) bool {
+	return a < b
+}
+
+func makeInts(size int, shape string) (v ints) {
+	v = make(ints, 0, size)
+	switch shape {
+
+	case "xor":
+		for i := 0; i < size; i++ {
+			v = append(v, 0xff&(i^0xab))
+		}
+
+	case "sorted":
+		for i := 0; i < size; i++ {
+			v = append(v, i)
+		}
+
+	case "revsorted":
+		for i := 0; i < size; i++ {
+			v = append(v, size-i)
+		}
+
+	case "random":
+		rand.Seed(1)
+
+		for i := 0; i < size; i++ {
+			v = append(v, rand.Int())
+		}
+
+	default:
+		panic(shape)
+	}
+
+	return v
+}
+
+func benchmarkTimsortI(b *testing.B, size int, shape string) {
+	b.StopTimer()
+
+	for j := 0; j < b.N; j++ {
+		v := makeInts(size, shape)
+
+		b.StartTimer()
+		Ints(v, LessThanInt)
+		b.StopTimer()
+	}
+}
+
+func benchmarkStandardSortI(b *testing.B, size int, shape string) {
+	b.StopTimer()
+
+	for j := 0; j < b.N; j++ {
+		v := makeInts(size, shape)
+
+		b.StartTimer()
+		sort.Sort(&v)
+		b.StopTimer()
+	}
+}
+
+func BenchmarkTimsortIXor100(b *testing.B) {
+	benchmarkTimsortI(b, 100, "xor")
+}
+
+func BenchmarkStandardSortIXor100(b *testing.B) {
+	benchmarkStandardSortI(b, 100, "xor")
+}
+
+func BenchmarkTimsortISorted100(b *testing.B) {
+	benchmarkTimsortI(b, 100, "sorted")
+}
+
+func BenchmarkStandardSortISorted100(b *testing.B) {
+	benchmarkStandardSortI(b, 100, "sorted")
+}
+
+func BenchmarkTimsortIRevSorted100(b *testing.B) {
+	benchmarkTimsortI(b, 100, "revsorted")
+}
+
+func BenchmarkStandardSortIRevSorted100(b *testing.B) {
+	benchmarkStandardSortI(b, 100, "revsorted")
+}
+
+func BenchmarkTimsortIRandom100(b *testing.B) {
+	benchmarkTimsortI(b, 100, "random")
+}
+
+func BenchmarkStandardSortIRandom100(b *testing.B) {
+	benchmarkStandardSortI(b, 100, "random")
+}
+
+func BenchmarkTimsortIXor1K(b *testing.B) {
+	benchmarkTimsortI(b, 1024, "xor")
+}
+
+func BenchmarkStandardSortIXor1K(b *testing.B) {
+	benchmarkStandardSortI(b, 1024, "xor")
+}
+
+func BenchmarkTimsortISorted1K(b *testing.B) {
+	benchmarkTimsortI(b, 1024, "sorted")
+}
+
+func BenchmarkStandardSortISorted1K(b *testing.B) {
+	benchmarkStandardSortI(b, 1024, "sorted")
+}
+
+func BenchmarkTimsortIRevSorted1K(b *testing.B) {
+	benchmarkTimsortI(b, 1024, "revsorted")
+}
+
+func BenchmarkStandardSortIRevSorted1K(b *testing.B) {
+	benchmarkStandardSortI(b, 1024, "revsorted")
+}
+
+func BenchmarkTimsortIRandom1K(b *testing.B) {
+	benchmarkTimsortI(b, 1024, "random")
+}
+
+func BenchmarkStandardSortIRandom1K(b *testing.B) {
+	benchmarkStandardSortI(b, 1024, "random")
+}
+
+func BenchmarkTimsortIXor1M(b *testing.B) {
+	benchmarkTimsortI(b, 1024*1024, "xor")
+}
+
+func BenchmarkStandardSortIXor1M(b *testing.B) {
+	benchmarkStandardSortI(b, 1024*1024, "xor")
+}
+
+func BenchmarkTimsortISorted1M(b *testing.B) {
+	benchmarkTimsortI(b, 1024*1024, "sorted")
+}
+
+func BenchmarkStandardSortISorted1M(b *testing.B) {
+	benchmarkStandardSortI(b, 1024*1024, "sorted")
+}
+
+func BenchmarkTimsortIRevSorted1M(b *testing.B) {
+	benchmarkTimsortI(b, 1024*1024, "revsorted")
+}
+
+func BenchmarkStandardSortIRevSorted1M(b *testing.B) {
+	benchmarkStandardSortI(b, 1024*1024, "revsorted")
+}
+
+func BenchmarkTimsortIRandom1M(b *testing.B) {
+	benchmarkTimsortI(b, 1024*1024, "random")
+}
+
+func BenchmarkStandardSortIRandom1M(b *testing.B) {
+	benchmarkStandardSortI(b, 1024*1024, "random")
+}

--- a/v3/benchstring_test.go
+++ b/v3/benchstring_test.go
@@ -1,0 +1,161 @@
+package timsort
+
+import (
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+func makeStrings(size int, shape string) (v sort.StringSlice) {
+	v = make(sort.StringSlice, 0, size)
+	switch shape {
+
+	case "xor":
+		for i := 0; i < size; i++ {
+			v = append(v, strconv.Itoa(0xff&(i^0xab)))
+		}
+
+	case "sorted":
+		for i := 0; i < size; i++ {
+			v = append(v, strconv.Itoa(i))
+		}
+
+	case "revsorted":
+		for i := 0; i < size; i++ {
+			v = append(v, strconv.Itoa(size-i))
+		}
+
+	case "random":
+		rand.Seed(1)
+
+		for i := 0; i < size; i++ {
+			v = append(v, strconv.Itoa(rand.Int()))
+		}
+
+	default:
+		panic(shape)
+	}
+
+	return v
+}
+
+func benchmarkTimsortStr(b *testing.B, size int, shape string) {
+	b.StopTimer()
+
+	for j := 0; j < b.N; j++ {
+		v := makeStrings(size, shape)
+
+		b.StartTimer()
+		TimSort(v)
+		b.StopTimer()
+	}
+}
+
+func benchmarkStandardSortStr(b *testing.B, size int, shape string) {
+	b.StopTimer()
+
+	for j := 0; j < b.N; j++ {
+		v := makeStrings(size, shape)
+
+		b.StartTimer()
+		sort.Sort(&v)
+		b.StopTimer()
+	}
+}
+
+func BenchmarkTimsortStrXor100(b *testing.B) {
+	benchmarkTimsortStr(b, 100, "xor")
+}
+
+func BenchmarkStandardSortStrXor100(b *testing.B) {
+	benchmarkStandardSortStr(b, 100, "xor")
+}
+
+func BenchmarkTimsortStrSorted100(b *testing.B) {
+	benchmarkTimsortStr(b, 100, "sorted")
+}
+
+func BenchmarkStandardSortStrSorted100(b *testing.B) {
+	benchmarkStandardSortStr(b, 100, "sorted")
+}
+
+func BenchmarkTimsortStrRevSorted100(b *testing.B) {
+	benchmarkTimsortStr(b, 100, "revsorted")
+}
+
+func BenchmarkStandardSortStrRevSorted100(b *testing.B) {
+	benchmarkStandardSortStr(b, 100, "revsorted")
+}
+
+func BenchmarkTimsortStrRandom100(b *testing.B) {
+	benchmarkTimsortStr(b, 100, "random")
+}
+
+func BenchmarkStandardSortStrRandom100(b *testing.B) {
+	benchmarkStandardSortStr(b, 100, "random")
+}
+
+func BenchmarkTimsortStrXor1K(b *testing.B) {
+	benchmarkTimsortStr(b, 1024, "xor")
+}
+
+func BenchmarkStandardSortStrXor1K(b *testing.B) {
+	benchmarkStandardSortStr(b, 1024, "xor")
+}
+
+func BenchmarkTimsortStrSorted1K(b *testing.B) {
+	benchmarkTimsortStr(b, 1024, "sorted")
+}
+
+func BenchmarkStandardSortStrSorted1K(b *testing.B) {
+	benchmarkStandardSortStr(b, 1024, "sorted")
+}
+
+func BenchmarkTimsortStrRevSorted1K(b *testing.B) {
+	benchmarkTimsortStr(b, 1024, "revsorted")
+}
+
+func BenchmarkStandardSortStrRevSorted1K(b *testing.B) {
+	benchmarkStandardSortStr(b, 1024, "revsorted")
+}
+
+func BenchmarkTimsortStrRandom1K(b *testing.B) {
+	benchmarkTimsortStr(b, 1024, "random")
+}
+
+func BenchmarkStandardSortStrRandom1K(b *testing.B) {
+	benchmarkStandardSortStr(b, 1024, "random")
+}
+
+func BenchmarkTimsortStrXor1M(b *testing.B) {
+	benchmarkTimsortStr(b, 1024*1024, "xor")
+}
+
+func BenchmarkStandardSortStrXor1M(b *testing.B) {
+	benchmarkStandardSortStr(b, 1024*1024, "xor")
+}
+
+func BenchmarkTimsortStrSorted1M(b *testing.B) {
+	benchmarkTimsortStr(b, 1024*1024, "sorted")
+}
+
+func BenchmarkStandardSortStrSorted1M(b *testing.B) {
+	benchmarkStandardSortStr(b, 1024*1024, "sorted")
+}
+
+func BenchmarkTimsortStrRevSorted1M(b *testing.B) {
+	benchmarkTimsortStr(b, 1024*1024, "revsorted")
+}
+
+func BenchmarkStandardSortStrRevSorted1M(b *testing.B) {
+	benchmarkStandardSortStr(b, 1024*1024, "revsorted")
+}
+
+func BenchmarkTimsortStrRandom1M(b *testing.B) {
+	benchmarkTimsortStr(b, 1024*1024, "random")
+}
+
+func BenchmarkStandardSortStrRandom1M(b *testing.B) {
+	benchmarkStandardSortStr(b, 1024*1024, "random")
+}

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,3 +1,3 @@
 module github.com/psilva261/timsort/v3
 
-go 1.14
+go 1.22

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,0 +1,3 @@
+module github.com/psilva261/timsort/v3
+
+go 1.14

--- a/v3/timsort.go
+++ b/v3/timsort.go
@@ -1,0 +1,948 @@
+// Package timsort provides fast stable sort, uses external comparator.
+//
+// A stable, adaptive, iterative mergesort that requires far fewer than
+// n lg(n) comparisons when running on partially sorted arrays, while
+// offering performance comparable to a traditional mergesort when run
+// on random arrays.  Like all proper mergesorts, this sort is stable and
+// runs O(n log n) time (worst case).  In the worst case, this sort requires
+// temporary storage space for n/2 object references; in the best case,
+// it requires only a small constant amount of space.
+//
+// This implementation was derived from Java's TimSort object by Josh Bloch,
+// which, in turn, was based on the original code by Tim Peters:
+//
+// http://svn.python.org/projects/python/trunk/Objects/listsort.txt
+//
+// Mike K.
+package timsort
+
+const (
+	/**
+	 * This is the minimum sized sequence that will be merged.  Shorter
+	 * sequences will be lengthened by calling binarySort.  If the entire
+	 * array is less than this length, no merges will be performed.
+	 *
+	 * This constant should be a power of two.  It was 64 in Tim Peter's C
+	 * implementation, but 32 was empirically determined to work better in
+	 * this implementation.  In the unlikely event that you set this constant
+	 * to be a number that's not a power of two, you'll need to change the
+	 * {@link #minRunLength} computation.
+	 *
+	 * If you decrease this constant, you must change the stackLen
+	 * computation in the TimSort constructor, or you risk an
+	 * ArrayOutOfBounds exception.  See listsort.txt for a discussion
+	 * of the minimum stack length required as a function of the length
+	 * of the array being sorted and the minimum merge sequence length.
+	 */
+	minMerge = 32
+	// mk: tried higher MIN_MERGE and got slower sorting (348->375)
+	//	c_MIN_MERGE = 64
+
+	/**
+	 * When we get into galloping mode, we stay there until both runs win less
+	 * often than cminGallop consecutive times.
+	 */
+	minGallop = 7
+
+	/**
+	 * Maximum initial size of tmp array, which is used for merging.  The array
+	 * can grow to accommodate demand.
+	 *
+	 * Unlike Tim's original C version, we do not allocate this much storage
+	 * when sorting smaller arrays.  This change was required for performance.
+	 */
+	initialTmpStorageLength = 256
+)
+
+// LessThan is Delegate type that sorting uses as a comparator
+type LessThan func(a, b interface{}) bool
+
+type timSortHandler struct {
+
+	/**
+	 * The array being sorted.
+	 */
+	a []interface{}
+
+	/**
+	 * The comparator for this sort.
+	 */
+	lt LessThan
+
+	/**
+	 * This controls when we get *into* galloping mode.  It is initialized
+	 * to cminGallop.  The mergeLo and mergeHi methods nudge it higher for
+	 * random data, and lower for highly structured data.
+	 */
+	minGallop int
+
+	/**
+	 * Temp storage for merges.
+	 */
+	tmp []interface{} // Actual runtime type will be Object[], regardless of T
+
+	/**
+	 * A stack of pending runs yet to be merged.  Run i starts at
+	 * address base[i] and extends for len[i] elements.  It's always
+	 * true (so long as the indices are in bounds) that:
+	 *
+	 *     runBase[i] + runLen[i] == runBase[i + 1]
+	 *
+	 * so we could cut the storage for this, but it's a minor amount,
+	 * and keeping all the info explicit simplifies the code.
+	 */
+	stackSize int // Number of pending runs on stack
+	runBase   []int
+	runLen    []int
+}
+
+/**
+ * Creates a TimSort instance to maintain the state of an ongoing sort.
+ *
+ * @param a the array to be sorted
+ * @param c the comparator to determine the order of the sort
+ */
+func newTimSort(a []interface{}, lt LessThan) (h *timSortHandler) {
+	h = new(timSortHandler)
+
+	h.a = a
+	h.lt = lt
+	h.minGallop = minGallop
+	h.stackSize = 0
+
+	// Allocate temp storage (which may be increased later if necessary)
+	len := len(a)
+
+	tmpSize := initialTmpStorageLength
+	if len < 2*tmpSize {
+		tmpSize = len / 2
+	}
+
+	h.tmp = make([]interface{}, tmpSize)
+
+	/*
+	 * Allocate runs-to-be-merged stack (which cannot be expanded).  The
+	 * stack length requirements are described in listsort.txt.  The C
+	 * version always uses the same stack length (85), but this was
+	 * measured to be too expensive when sorting "mid-sized" arrays (e.g.,
+	 * 100 elements) in Java.  Therefore, we use smaller (but sufficiently
+	 * large) stack lengths for smaller arrays.  The "magic numbers" in the
+	 * computation below must be changed if c_MIN_MERGE is decreased.  See
+	 * the c_MIN_MERGE declaration above for more information.
+	 */
+	// mk: confirmed that for small sorts this optimization gives measurable (albeit small)
+	// performance enhancement
+	stackLen := 40
+	if len < 120 {
+		stackLen = 5
+	} else if len < 1542 {
+		stackLen = 10
+	} else if len < 119151 {
+		stackLen = 19
+	}
+
+	h.runBase = make([]int, stackLen)
+	h.runLen = make([]int, stackLen)
+
+	return h
+}
+
+// Sort an array using the provided comparator
+func Sort(a []interface{}, lt LessThan) {
+	lo := 0
+	hi := len(a)
+	nRemaining := hi
+
+	if nRemaining < 2 {
+		return // Arrays of size 0 and 1 are always sorted
+	}
+
+	// If array is small, do a "mini-TimSort" with no merges
+	if nRemaining < minMerge {
+		initRunLen := countRunAndMakeAscending(a, lo, hi, lt)
+
+		binarySort(a, lo, hi, lo+initRunLen, lt)
+		return
+	}
+
+	/**
+	 * March over the array once, left to right, finding natural runs,
+	 * extending short natural runs to minRun elements, and merging runs
+	 * to maintain stack invariant.
+	 */
+
+	ts := newTimSort(a, lt)
+	minRun := minRunLength(nRemaining)
+	for {
+		// Identify next run
+		runLen := countRunAndMakeAscending(a, lo, hi, lt)
+
+		// If run is short, extend to min(minRun, nRemaining)
+		if runLen < minRun {
+			force := minRun
+			if nRemaining <= minRun {
+				force = nRemaining
+			}
+			binarySort(a, lo, lo+force, lo+runLen, lt)
+			runLen = force
+		}
+
+		// Push run onto pending-run stack, and maybe merge
+		ts.pushRun(lo, runLen)
+		ts.mergeCollapse()
+
+		// Advance to find next run
+		lo += runLen
+		nRemaining -= runLen
+		if nRemaining == 0 {
+			break
+		}
+	}
+
+	ts.mergeForceCollapse()
+}
+
+/**
+ * Sorts the specified portion of the specified array using a binary
+ * insertion sort.  This is the best method for sorting small numbers
+ * of elements.  It requires O(n log n) compares, but O(n^2) data
+ * movement (worst case).
+ *
+ * If the initial part of the specified range is already sorted,
+ * this method can take advantage of it: the method assumes that the
+ * elements from index {@code lo}, inclusive, to {@code start},
+ * exclusive are already sorted.
+ *
+ * @param a the array in which a range is to be sorted
+ * @param lo the index of the first element in the range to be sorted
+ * @param hi the index after the last element in the range to be sorted
+ * @param start the index of the first element in the range that is
+ *        not already known to be sorted (@code lo <= start <= hi}
+ * @param c comparator to used for the sort
+ */
+func binarySort(a []interface{}, lo, hi, start int, lt LessThan) {
+	if start == lo {
+		start++
+	}
+
+	for ; start < hi; start++ {
+		pivot := a[start]
+
+		// Set left (and right) to the index where a[start] (pivot) belongs
+		left := lo
+		right := start
+
+		/*
+		 * Invariants:
+		 *   pivot >= all in [lo, left).
+		 *   pivot <  all in [right, start).
+		 */
+		for left < right {
+			mid := int(uint(left+right) >> 1)
+			if lt(pivot, a[mid]) {
+				right = mid
+			} else {
+				left = mid + 1
+			}
+		}
+
+		/*
+		 * The invariants still hold: pivot >= all in [lo, left) and
+		 * pivot < all in [left, start), so pivot belongs at left.  Note
+		 * that if there are elements equal to pivot, left points to the
+		 * first slot after them -- that's why this sort is stable.
+		 * Slide elements over to make room to make room for pivot.
+		 */
+		n := start - left // The number of elements to move
+		// just an optimization for copy in default case
+		if n <= 2 {
+			if n == 2 {
+				a[left+2] = a[left+1]
+			}
+			if n > 0 {
+				a[left+1] = a[left]
+			}
+		} else {
+			copy(a[left+1:], a[left:left+n])
+		}
+		a[left] = pivot
+	}
+}
+
+/**
+  * Returns the length of the run beginning at the specified position in
+  * the specified array and reverses the run if it is descending (ensuring
+  * that the run will always be ascending when the method returns).
+  *
+  * A run is the longest ascending sequence with:
+  *
+  *    a[lo] <= a[lo + 1] <= a[lo + 2] <= ...
+  *
+  * or the longest descending sequence with:
+  *
+  *    a[lo] >  a[lo + 1] >  a[lo + 2] >  ...
+  *
+  * For its intended use in a stable mergesort, the strictness of the
+  * definition of "descending" is needed so that the call can safely
+  * reverse a descending sequence without violating stability.
+  *
+  * @param a the array in which a run is to be counted and possibly reversed
+  * @param lo index of the first element in the run
+  * @param hi index after the last element that may be contained in the run.
+           It is required that @code{lo < hi}.
+  * @param c the comparator to used for the sort
+  * @return  the length of the run beginning at the specified position in
+  *          the specified array
+*/
+func countRunAndMakeAscending(a []interface{}, lo, hi int, lt LessThan) int {
+	runHi := lo + 1
+	if runHi == hi {
+		return 1
+	}
+
+	// Find end of run, and reverse range if descending
+	if lt(a[runHi], a[lo]) { // Descending
+		runHi++
+
+		for runHi < hi && lt(a[runHi], a[runHi-1]) {
+			runHi++
+		}
+		reverseRange(a, lo, runHi)
+	} else { // Ascending
+		for runHi < hi && !lt(a[runHi], a[runHi-1]) {
+			runHi++
+		}
+	}
+
+	return runHi - lo
+}
+
+/**
+ * Reverse the specified range of the specified array.
+ *
+ * @param a the array in which a range is to be reversed
+ * @param lo the index of the first element in the range to be reversed
+ * @param hi the index after the last element in the range to be reversed
+ */
+func reverseRange(a []interface{}, lo, hi int) {
+	hi--
+	for lo < hi {
+		a[lo], a[hi] = a[hi], a[lo]
+		lo++
+		hi--
+	}
+}
+
+/**
+ * Returns the minimum acceptable run length for an array of the specified
+ * length. Natural runs shorter than this will be extended with
+ * {@link #binarySort}.
+ *
+ * Roughly speaking, the computation is:
+ *
+ *  If n < c_MIN_MERGE, return n (it's too small to bother with fancy stuff).
+ *  Else if n is an exact power of 2, return c_MIN_MERGE/2.
+ *  Else return an int k, c_MIN_MERGE/2 <= k <= c_MIN_MERGE, such that n/k
+ *   is close to, but strictly less than, an exact power of 2.
+ *
+ * For the rationale, see listsort.txt.
+ *
+ * @param n the length of the array to be sorted
+ * @return the length of the minimum run to be merged
+ */
+func minRunLength(n int) int {
+	r := 0 // Becomes 1 if any 1 bits are shifted off
+	for n >= minMerge {
+		r |= (n & 1)
+		n >>= 1
+	}
+	return n + r
+}
+
+/**
+ * Pushes the specified run onto the pending-run stack.
+ *
+ * @param runBase index of the first element in the run
+ * @param runLen  the number of elements in the run
+ */
+func (h *timSortHandler) pushRun(runBase, runLen int) {
+	h.runBase[h.stackSize] = runBase
+	h.runLen[h.stackSize] = runLen
+	h.stackSize++
+}
+
+/**
+ * Examines the stack of runs waiting to be merged and merges adjacent runs
+ * until the stack invariants are reestablished:
+ *
+ *     1. runLen[i - 3] > runLen[i - 2] + runLen[i - 1]
+ *     2. runLen[i - 2] > runLen[i - 1]
+ *
+ * This method is called each time a new run is pushed onto the stack,
+ * so the invariants are guaranteed to hold for i < stackSize upon
+ * entry to the method.
+ */
+func (h *timSortHandler) mergeCollapse() {
+	for h.stackSize > 1 {
+		n := h.stackSize - 2
+		if (n > 0 && h.runLen[n-1] <= h.runLen[n]+h.runLen[n+1]) ||
+			(n > 1 && h.runLen[n-2] <= h.runLen[n-1]+h.runLen[n]) {
+			if h.runLen[n-1] < h.runLen[n+1] {
+				n--
+			}
+			h.mergeAt(n)
+		} else if h.runLen[n] <= h.runLen[n+1] {
+			h.mergeAt(n)
+		} else {
+			break // Invariant is established
+		}
+	}
+}
+
+/**
+ * Merges all runs on the stack until only one remains.  This method is
+ * called once, to complete the sort.
+ */
+func (h *timSortHandler) mergeForceCollapse() {
+	for h.stackSize > 1 {
+		n := h.stackSize - 2
+		if n > 0 && h.runLen[n-1] < h.runLen[n+1] {
+			n--
+		}
+		h.mergeAt(n)
+	}
+}
+
+/**
+ * Merges the two runs at stack indices i and i+1.  Run i must be
+ * the penultimate or antepenultimate run on the stack.  In other words,
+ * i must be equal to stackSize-2 or stackSize-3.
+ *
+ * @param i stack index of the first of the two runs to merge
+ */
+func (h *timSortHandler) mergeAt(i int) {
+	base1 := h.runBase[i]
+	len1 := h.runLen[i]
+	base2 := h.runBase[i+1]
+	len2 := h.runLen[i+1]
+
+	/*
+	 * Record the length of the combined runs; if i is the 3rd-last
+	 * run now, also slide over the last run (which isn't involved
+	 * in this merge).  The current run (i+1) goes away in any case.
+	 */
+	h.runLen[i] = len1 + len2
+	if i == h.stackSize-3 {
+		h.runBase[i+1] = h.runBase[i+2]
+		h.runLen[i+1] = h.runLen[i+2]
+	}
+	h.stackSize--
+
+	/*
+	 * Find where the first element of run2 goes in run1. Prior elements
+	 * in run1 can be ignored (because they're already in place).
+	 */
+	k := gallopRight(h.a[base2], h.a, base1, len1, 0, h.lt)
+	base1 += k
+	len1 -= k
+	if len1 == 0 {
+		return
+	}
+
+	/*
+	 * Find where the last element of run1 goes in run2. Subsequent elements
+	 * in run2 can be ignored (because they're already in place).
+	 */
+	len2 = gallopLeft(h.a[base1+len1-1], h.a, base2, len2, len2-1, h.lt)
+	if len2 == 0 {
+		return
+	}
+
+	// Merge remaining runs, using tmp array with min(len1, len2) elements
+	if len1 <= len2 {
+		h.mergeLo(base1, len1, base2, len2)
+	} else {
+		h.mergeHi(base1, len1, base2, len2)
+	}
+}
+
+/**
+ * Locates the position at which to insert the specified key into the
+ * specified sorted range; if the range contains an element equal to key,
+ * returns the index of the leftmost equal element.
+ *
+ * @param key the key whose insertion point to search for
+ * @param a the array in which to search
+ * @param base the index of the first element in the range
+ * @param len the length of the range; must be > 0
+ * @param hint the index at which to begin the search, 0 <= hint < n.
+ *     The closer hint is to the result, the faster this method will run.
+ * @param c the comparator used to order the range, and to search
+ * @return the int k,  0 <= k <= n such that a[b + k - 1] < key <= a[b + k],
+ *    pretending that a[b - 1] is minus infinity and a[b + n] is infinity.
+ *    In other words, key belongs at index b + k; or in other words,
+ *    the first k elements of a should precede key, and the last n - k
+ *    should follow it.
+ */
+func gallopLeft(key interface{}, a []interface{}, base, len, hint int, c LessThan) int {
+	lastOfs := 0
+	ofs := 1
+
+	if c(a[base+hint], key) {
+		// Gallop right until a[base+hint+lastOfs] < key <= a[base+hint+ofs]
+		maxOfs := len - hint
+		for ofs < maxOfs && c(a[base+hint+ofs], key) {
+			lastOfs = ofs
+			ofs = (ofs << 1) + 1
+			if ofs <= 0 { // int overflow
+				ofs = maxOfs
+			}
+		}
+		if ofs > maxOfs {
+			ofs = maxOfs
+		}
+
+		// Make offsets relative to base
+		lastOfs += hint
+		ofs += hint
+	} else { // key <= a[base + hint]
+		// Gallop left until a[base+hint-ofs] < key <= a[base+hint-lastOfs]
+		maxOfs := hint + 1
+		for ofs < maxOfs && !c(a[base+hint-ofs], key) {
+			lastOfs = ofs
+			ofs = (ofs << 1) + 1
+			if ofs <= 0 { // int overflow
+				ofs = maxOfs
+			}
+		}
+		if ofs > maxOfs {
+			ofs = maxOfs
+		}
+
+		// Make offsets relative to base
+		tmp := lastOfs
+		lastOfs = hint - ofs
+		ofs = hint - tmp
+	}
+
+	/*
+	 * Now a[base+lastOfs] < key <= a[base+ofs], so key belongs somewhere
+	 * to the right of lastOfs but no farther right than ofs.  Do a binary
+	 * search, with invariant a[base + lastOfs - 1] < key <= a[base + ofs].
+	 */
+	lastOfs++
+	for lastOfs < ofs {
+		m := lastOfs + (ofs-lastOfs)/2
+
+		if c(a[base+m], key) {
+			lastOfs = m + 1 // a[base + m] < key
+		} else {
+			ofs = m // key <= a[base + m]
+		}
+	}
+
+	return ofs
+}
+
+/**
+ * Like gallopLeft, except that if the range contains an element equal to
+ * key, gallopRight returns the index after the rightmost equal element.
+ *
+ * @param key the key whose insertion point to search for
+ * @param a the array in which to search
+ * @param base the index of the first element in the range
+ * @param len the length of the range; must be > 0
+ * @param hint the index at which to begin the search, 0 <= hint < n.
+ *     The closer hint is to the result, the faster this method will run.
+ * @param c the comparator used to order the range, and to search
+ * @return the int k,  0 <= k <= n such that a[b + k - 1] <= key < a[b + k]
+ */
+func gallopRight(key interface{}, a []interface{}, base, len, hint int, c LessThan) int {
+	ofs := 1
+	lastOfs := 0
+	if c(key, a[base+hint]) {
+		// Gallop left until a[b+hint - ofs] <= key < a[b+hint - lastOfs]
+		maxOfs := hint + 1
+		for ofs < maxOfs && c(key, a[base+hint-ofs]) {
+			lastOfs = ofs
+			ofs = (ofs << 1) + 1
+			if ofs <= 0 { // int overflow
+				ofs = maxOfs
+			}
+		}
+		if ofs > maxOfs {
+			ofs = maxOfs
+		}
+
+		// Make offsets relative to b
+		tmp := lastOfs
+		lastOfs = hint - ofs
+		ofs = hint - tmp
+	} else { // a[b + hint] <= key
+		// Gallop right until a[b+hint + lastOfs] <= key < a[b+hint + ofs]
+		maxOfs := len - hint
+		for ofs < maxOfs && !c(key, a[base+hint+ofs]) {
+			lastOfs = ofs
+			ofs = (ofs << 1) + 1
+			if ofs <= 0 { // int overflow
+				ofs = maxOfs
+			}
+		}
+		if ofs > maxOfs {
+			ofs = maxOfs
+		}
+
+		// Make offsets relative to b
+		lastOfs += hint
+		ofs += hint
+	}
+
+	/*
+	 * Now a[b + lastOfs] <= key < a[b + ofs], so key belongs somewhere to
+	 * the right of lastOfs but no farther right than ofs.  Do a binary
+	 * search, with invariant a[b + lastOfs - 1] <= key < a[b + ofs].
+	 */
+	lastOfs++
+	for lastOfs < ofs {
+		m := lastOfs + (ofs-lastOfs)/2
+
+		if c(key, a[base+m]) {
+			ofs = m // key < a[b + m]
+		} else {
+			lastOfs = m + 1 // a[b + m] <= key
+		}
+	}
+	return ofs
+}
+
+/**
+ * Merges two adjacent runs in place, in a stable fashion.  The first
+ * element of the first run must be greater than the first element of the
+ * second run (a[base1] > a[base2]), and the last element of the first run
+ * (a[base1 + len1-1]) must be greater than all elements of the second run.
+ *
+ * For performance, this method should be called only when len1 <= len2;
+ * its twin, mergeHi should be called if len1 >= len2.  (Either method
+ * may be called if len1 == len2.)
+ *
+ * @param base1 index of first element in first run to be merged
+ * @param len1  length of first run to be merged (must be > 0)
+ * @param base2 index of first element in second run to be merged
+ *        (must be aBase + aLen)
+ * @param len2  length of second run to be merged (must be > 0)
+ */
+func (h *timSortHandler) mergeLo(base1, len1, base2, len2 int) {
+	// Copy first run into temp array
+	a := h.a // For performance
+	tmp := h.ensureCapacity(len1)
+
+	copy(tmp, a[base1:base1+len1])
+
+	cursor1 := 0     // Indexes into tmp array
+	cursor2 := base2 // Indexes int a
+	dest := base1    // Indexes int a
+
+	// Move first element of second run and deal with degenerate cases
+	a[dest] = a[cursor2]
+	dest++
+	cursor2++
+	len2--
+	if len2 == 0 {
+		copy(a[dest:dest+len1], tmp)
+		return
+	}
+	if len1 == 1 {
+		copy(a[dest:dest+len2], a[cursor2:cursor2+len2])
+		a[dest+len2] = tmp[cursor1] // Last elt of run 1 to end of merge
+		return
+	}
+
+	lt := h.lt               // Use local variable for performance
+	minGallop := h.minGallop //  "    "       "     "      "
+
+outer:
+	for {
+		count1 := 0 // Number of times in a row that first run won
+		count2 := 0 // Number of times in a row that second run won
+
+		/*
+		 * Do the straightforward thing until (if ever) one run starts
+		 * winning consistently.
+		 */
+		for {
+			if lt(a[cursor2], tmp[cursor1]) {
+				a[dest] = a[cursor2]
+				dest++
+				cursor2++
+				count2++
+				count1 = 0
+				len2--
+				if len2 == 0 {
+					break outer
+				}
+			} else {
+				a[dest] = tmp[cursor1]
+				dest++
+				cursor1++
+				count1++
+				count2 = 0
+				len1--
+				if len1 == 1 {
+					break outer
+				}
+			}
+			if (count1 | count2) >= minGallop {
+				break
+			}
+		}
+
+		/*
+		 * One run is winning so consistently that galloping may be a
+		 * huge win. So try that, and continue galloping until (if ever)
+		 * neither run appears to be winning consistently anymore.
+		 */
+		for {
+			count1 = gallopRight(a[cursor2], tmp, cursor1, len1, 0, lt)
+			if count1 != 0 {
+				copy(a[dest:dest+count1], tmp[cursor1:cursor1+count1])
+				dest += count1
+				cursor1 += count1
+				len1 -= count1
+				if len1 <= 1 { // len1 == 1 || len1 == 0
+					break outer
+				}
+			}
+			a[dest] = a[cursor2]
+			dest++
+			cursor2++
+			len2--
+			if len2 == 0 {
+				break outer
+			}
+
+			count2 = gallopLeft(tmp[cursor1], a, cursor2, len2, 0, lt)
+			if count2 != 0 {
+				copy(a[dest:dest+count2], a[cursor2:cursor2+count2])
+				dest += count2
+				cursor2 += count2
+				len2 -= count2
+				if len2 == 0 {
+					break outer
+				}
+			}
+			a[dest] = tmp[cursor1]
+			dest++
+			cursor1++
+			len1--
+			if len1 == 1 {
+				break outer
+			}
+			minGallop--
+			if count1 < minGallop && count2 < minGallop {
+				break
+			}
+		}
+		if minGallop < 0 {
+			minGallop = 0
+		}
+		minGallop += 2 // Penalize for leaving gallop mode
+	} // End of "outer" loop
+
+	if minGallop < 1 {
+		minGallop = 1
+	}
+	h.minGallop = minGallop // Write back to field
+
+	if len1 == 1 {
+
+		copy(a[dest:dest+len2], a[cursor2:cursor2+len2])
+		a[dest+len2] = tmp[cursor1] //  Last elt of run 1 to end of merge
+	} else {
+		copy(a[dest:dest+len1], tmp[cursor1:cursor1+len1])
+	}
+}
+
+/**
+ * Like mergeLo, except that this method should be called only if
+ * len1 >= len2; mergeLo should be called if len1 <= len2.  (Either method
+ * may be called if len1 == len2.)
+ *
+ * @param base1 index of first element in first run to be merged
+ * @param len1  length of first run to be merged (must be > 0)
+ * @param base2 index of first element in second run to be merged
+ *        (must be aBase + aLen)
+ * @param len2  length of second run to be merged (must be > 0)
+ */
+func (h *timSortHandler) mergeHi(base1, len1, base2, len2 int) {
+	// Copy second run into temp array
+	a := h.a // For performance
+	tmp := h.ensureCapacity(len2)
+
+	copy(tmp, a[base2:base2+len2])
+
+	cursor1 := base1 + len1 - 1 // Indexes into a
+	cursor2 := len2 - 1         // Indexes into tmp array
+	dest := base2 + len2 - 1    // Indexes into a
+
+	// Move last element of first run and deal with degenerate cases
+	a[dest] = a[cursor1]
+	dest--
+	cursor1--
+	len1--
+	if len1 == 0 {
+		dest -= len2 - 1
+		copy(a[dest:dest+len2], tmp)
+		return
+	}
+	if len2 == 1 {
+		dest -= len1 - 1
+		cursor1 -= len1 - 1
+		copy(a[dest:dest+len1], a[cursor1:cursor1+len1])
+		a[dest-1] = tmp[cursor2]
+		return
+	}
+
+	lt := h.lt               // Use local variable for performance
+	minGallop := h.minGallop //  "    "       "     "      "
+
+outer:
+	for {
+		count1 := 0 // Number of times in a row that first run won
+		count2 := 0 // Number of times in a row that second run won
+
+		/*
+		 * Do the straightforward thing until (if ever) one run
+		 * appears to win consistently.
+		 */
+		for {
+			if lt(tmp[cursor2], a[cursor1]) {
+				a[dest] = a[cursor1]
+				dest--
+				cursor1--
+				count1++
+				count2 = 0
+				len1--
+				if len1 == 0 {
+					break outer
+				}
+			} else {
+				a[dest] = tmp[cursor2]
+				dest--
+				cursor2--
+				count2++
+				count1 = 0
+				len2--
+				if len2 == 1 {
+					break outer
+				}
+			}
+			if (count1 | count2) >= minGallop {
+				break
+			}
+		}
+
+		/*
+		 * One run is winning so consistently that galloping may be a
+		 * huge win. So try that, and continue galloping until (if ever)
+		 * neither run appears to be winning consistently anymore.
+		 */
+		for {
+			gr := gallopRight(tmp[cursor2], a, base1, len1, len1-1, lt)
+			count1 = len1 - gr
+			if count1 != 0 {
+				dest -= count1
+				cursor1 -= count1
+				len1 -= count1
+				copy(a[dest+1:dest+1+count1], a[cursor1+1:cursor1+1+count1])
+				if len1 == 0 {
+					break outer
+				}
+			}
+			a[dest] = tmp[cursor2]
+			dest--
+			cursor2--
+			len2--
+			if len2 == 1 {
+				break outer
+			}
+
+			gl := gallopLeft(a[cursor1], tmp, 0, len2, len2-1, lt)
+			count2 = len2 - gl
+			if count2 != 0 {
+				dest -= count2
+				cursor2 -= count2
+				len2 -= count2
+				copy(a[dest+1:dest+1+count2], tmp[cursor2+1:cursor2+1+count2])
+				if len2 <= 1 { // len2 == 1 || len2 == 0
+					break outer
+				}
+			}
+			a[dest] = a[cursor1]
+			dest--
+			cursor1--
+			len1--
+			if len1 == 0 {
+				break outer
+			}
+			minGallop--
+
+			if count1 < minGallop && count2 < minGallop {
+				break
+			}
+		}
+		if minGallop < 0 {
+			minGallop = 0
+		}
+		minGallop += 2 // Penalize for leaving gallop mode
+	} // End of "outer" loop
+
+	if minGallop < 1 {
+		minGallop = 1
+	}
+
+	h.minGallop = minGallop // Write back to field
+
+	if len2 == 1 {
+		dest -= len1
+		cursor1 -= len1
+
+		copy(a[dest+1:dest+1+len1], a[cursor1+1:cursor1+1+len1])
+		a[dest] = tmp[cursor2] // Move first elt of run2 to front of merge
+	} else {
+		copy(a[dest-(len2-1):dest+1], tmp)
+	}
+}
+
+/**
+ * Ensures that the external array tmp has at least the specified
+ * number of elements, increasing its size if necessary.  The size
+ * increases exponentially to ensure amortized linear time complexity.
+ *
+ * @param minCapacity the minimum required capacity of the tmp array
+ * @return tmp, whether or not it grew
+ */
+func (h *timSortHandler) ensureCapacity(minCapacity int) []interface{} {
+	if len(h.tmp) < minCapacity {
+		// Compute smallest power of 2 > minCapacity
+		newSize := minCapacity
+		newSize |= newSize >> 1
+		newSize |= newSize >> 2
+		newSize |= newSize >> 4
+		newSize |= newSize >> 8
+		newSize |= newSize >> 16
+		newSize++
+
+		if newSize < 0 { // Not bloody likely!
+			newSize = minCapacity
+		} else {
+			ns := len(h.a) / 2
+			if ns < newSize {
+				newSize = ns
+			}
+		}
+
+		h.tmp = make([]interface{}, newSize)
+	}
+
+	return h.tmp
+}

--- a/v3/timsort_test.go
+++ b/v3/timsort_test.go
@@ -1,0 +1,354 @@
+package timsort
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+type val struct {
+	key, order int
+}
+
+func makeTestArray(size int) []interface{} {
+	a := make([]interface{}, size)
+
+	for i := 0; i < size; i++ {
+		a[i] = val{i & 0xeeeeee, i}
+	}
+
+	return a
+}
+
+func IsSorted(a []interface{}, lessThan LessThan) bool {
+	len := len(a)
+
+	if len < 2 {
+		return true
+	}
+
+	prev := a[0]
+	for i := 1; i < len; i++ {
+		if lessThan(a[i], prev) {
+			return false
+		}
+		prev = a[i]
+	}
+
+	return true
+}
+
+func TestIsSorted(t *testing.T) {
+	a := make([]interface{}, 5)
+	a[0] = val{3, 1}
+	a[1] = val{1, 5}
+	a[2] = val{2, 3}
+	a[3] = val{3, 4}
+	a[4] = val{4, 5}
+
+	if IsSorted(a, OrderLessThan) {
+		t.Error("Sorted")
+	}
+
+}
+
+// use this comparator for sorting
+func KeyLessThan(a, b interface{}) bool {
+	return a.(val).key < b.(val).key
+}
+
+type KeyLessThanSlice []interface{}
+
+func (s KeyLessThanSlice) Len() int {
+	return len(s)
+}
+
+func (s KeyLessThanSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s KeyLessThanSlice) Less(i, j int) bool {
+	return s[i].(val).key < s[j].(val).key
+}
+
+// use this comparator to validate sorted data (and prove its stable)
+func KeyOrderLessThan(a, b interface{}) bool {
+	if a.(val).key < b.(val).key {
+		return true
+	} else if a.(val).key == b.(val).key {
+		return a.(val).order < b.(val).order
+	}
+
+	return false
+}
+
+// use this comparator to restore the original order of elements (by sorting on order field)
+func OrderLessThan(a, b interface{}) bool {
+	return a.(val).order < b.(val).order
+}
+
+type OrderLessThanSlice []interface{}
+
+func (s OrderLessThanSlice) Len() int {
+	return len(s)
+}
+
+func (s OrderLessThanSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s OrderLessThanSlice) Less(i, j int) bool {
+	return s[i].(val).order < s[j].(val).order
+}
+
+func TestSmoke(t *testing.T) {
+	a := make([]interface{}, 3)
+	a[0] = val{3, 0}
+	a[1] = val{1, 1}
+	a[2] = val{2, 2}
+
+	Sort(a, KeyLessThan)
+
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func TestSmokeStability(t *testing.T) {
+	a := make([]interface{}, 3)
+	a[0] = val{3, 0}
+	a[1] = val{2, 1}
+	a[2] = val{2, 2}
+
+	Sort(a, KeyLessThan)
+
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test0(t *testing.T) {
+	a := makeTestArray(0)
+
+	Sort(a, KeyLessThan)
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test1(t *testing.T) {
+	a := makeTestArray(1)
+
+	Sort(a, KeyLessThan)
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test1K(t *testing.T) {
+	a := makeTestArray(1024)
+
+	Sort(a, KeyLessThan)
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test100K(t *testing.T) {
+	a := makeTestArray(100 * 1024)
+
+	Sort(a, KeyLessThan)
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test1M(t *testing.T) {
+	a := makeTestArray(1024 * 1024)
+
+	Sort(a, KeyLessThan)
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func TestConst(t *testing.T) {
+	a := []interface{}{val{1, 1}, val{1, 1}, val{1, 1}}
+
+	Sort(a, KeyLessThan)
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func makeRandomArray(size int) []interface{} {
+	a := make([]interface{}, size)
+
+	for i := 0; i < size; i++ {
+		a[i] = val{rand.Intn(100), i}
+	}
+
+	return a
+}
+
+func Equals(a, b interface{}) bool {
+	return a.(val).key == b.(val).key && a.(val).order == b.(val).order
+}
+
+func TestRandom1M(t *testing.T) {
+	size := 1024 * 1024
+
+	a := makeRandomArray(size)
+	b := make([]interface{}, size)
+	copy(b, a)
+
+	Sort(a, KeyLessThan)
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+
+	// sort by order
+	Sort(a, OrderLessThan)
+	for i := 0; i < len(b); i++ {
+		if !Equals(b[i], a[i]) {
+			t.Error("oops")
+		}
+	}
+}
+
+const (
+	_Sawtooth = iota
+	_Rand
+	_Stagger
+	_Plateau
+	_Shuffle
+	_NDist
+)
+
+const (
+	_Copy = iota
+	_Reverse
+	_ReverseFirstHalf
+	_ReverseSecondHalf
+	_Sorted
+	_Dither
+	_NMode
+)
+
+func TestBentleyMcIlroy(t *testing.T) {
+	//	sizes := []int{100, 1023, 1024, 1025, 1023 * 1023, 1024 * 1024, 1025 * 1025}
+	sizes := []int{100, 1023, 1024, 1025}
+	dists := []string{"sawtooth", "rand", "stagger", "plateau", "shuffle"}
+	modes := []string{"copy", "reverse", "reverse1", "reverse2", "sort", "dither"}
+	tmp1 := make([]interface{}, 1025*1025)
+	tmp2 := make([]interface{}, 1025*1025)
+	for ni := 0; ni < len(sizes); ni++ {
+		n := sizes[ni]
+		for m := 1; m < 2*n; m *= 2 {
+			for dist := 0; dist < _NDist; dist++ {
+				j := 0
+				k := 1
+				data := tmp1[0:n]
+				for i := 0; i < n; i++ {
+					switch dist {
+					case _Sawtooth:
+						data[i] = val{i % m, i}
+					case _Rand:
+						data[i] = val{rand.Intn(m), i}
+					case _Stagger:
+						data[i] = val{(i*m + i) % n, i}
+					case _Plateau:
+						if i < m {
+							data[i] = val{i, i}
+						} else {
+							data[i] = val{m, i}
+						}
+					case _Shuffle:
+						if rand.Intn(m) != 0 {
+							j += 2
+							data[i] = val{j, i}
+						} else {
+							k += 2
+							data[i] = val{k, i}
+						}
+					}
+				}
+
+				mdata := tmp2[0:n]
+				for mode := 0; mode < _NMode; mode++ {
+					switch mode {
+					case _Copy:
+						for i := 0; i < n; i++ {
+							mdata[i] = val{data[i].(val).key, i}
+						}
+					case _Reverse:
+						for i := 0; i < n; i++ {
+							mdata[i] = val{data[n-i-1].(val).key, i}
+						}
+					case _ReverseFirstHalf:
+						for i := 0; i < n/2; i++ {
+							mdata[i] = val{data[n/2-i-1].(val).key, i}
+						}
+						for i := n / 2; i < n; i++ {
+							mdata[i] = val{data[i].(val).key, i}
+						}
+					case _ReverseSecondHalf:
+						for i := 0; i < n/2; i++ {
+							mdata[i] = val{data[i].(val).key, i}
+						}
+						for i := n / 2; i < n; i++ {
+							mdata[i] = val{data[n-(i-n/2)-1].(val).key, i}
+						}
+					case _Sorted:
+						for i := 0; i < n; i++ {
+							mdata[i] = data[i]
+						}
+						// SortInts is known to be correct
+						// because mode Sort runs after mode _Copy.
+						Sort(mdata, KeyLessThan)
+					case _Dither:
+						for i := 0; i < n; i++ {
+							mdata[i] = val{data[i].(val).key + i%5, i}
+						}
+					}
+
+					desc := fmt.Sprintf("n=%d m=%d dist=%s mode=%s", n, m, dists[dist], modes[mode])
+
+					for i := 0; i < len(mdata); i++ {
+						mdata[i] = val{mdata[i].(val).key, i}
+					}
+
+					gdata := make([]interface{}, len(mdata))
+					copy(gdata, mdata)
+
+					Sort(mdata, KeyLessThan)
+
+					// If we were testing C qsort, we'd have to make a copy
+					// of the array and sort it ourselves and then compare
+					// x against it, to ensure that qsort was only permuting
+					// the data, not (for example) overwriting it with zeros.
+					//
+					// In go, we don't have to be so paranoid: since the only
+					// mutating method Sort can call is TestingData.swap,
+					// it suffices here just to check that the final array is sorted.
+					if !IsSorted(mdata, KeyOrderLessThan) {
+						t.Errorf("%s: ints not sorted", desc)
+						t.Errorf("\t%v", mdata)
+						t.FailNow()
+					}
+
+					Sort(mdata, OrderLessThan)
+					for i := 0; i < len(data); i++ {
+						if !Equals(gdata[i], mdata[i]) {
+							t.Error("restore sort failed")
+							t.Errorf("gdata=%v", gdata)
+							t.Errorf("mdata=%v", mdata)
+							t.Errorf("bad index: %v\n", i)
+							t.FailNow()
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/v3/timsortint.go
+++ b/v3/timsortint.go
@@ -1,0 +1,870 @@
+package timsort
+
+import ()
+
+// IntLessThan is a Delegate type that sorting uses as a comparator
+type IntLessThan func(a, b int) bool
+
+type timSortHandlerI struct {
+
+	/**
+	 * The array being sorted.
+	 */
+	a []int
+
+	/**
+	 * The comparator for this sort.
+	 */
+	lt IntLessThan
+
+	/**
+	 * This controls when we get *into* galloping mode.  It is initialized
+	 * to c_MIN_GALLOP.  The mergeLo and mergeHi methods nudge it higher for
+	 * random data, and lower for highly structured data.
+	 */
+	minGallop int
+
+	/**
+	 * Temp storage for merges.
+	 */
+	tmp []int // Actual runtime type will be Object[], regardless of T
+
+	/**
+	 * A stack of pending runs yet to be merged.  Run i starts at
+	 * address base[i] and extends for len[i] elements.  It's always
+	 * true (so long as the indices are in bounds) that:
+	 *
+	 *     runBase[i] + runLen[i] == runBase[i + 1]
+	 *
+	 * so we could cut the storage for this, but it's a minor amount,
+	 * and keeping all the info explicit simplifies the code.
+	 */
+	stackSize int // Number of pending runs on stack
+	runBase   []int
+	runLen    []int
+}
+
+/**
+ * Creates a TimSort instance to maintain the state of an ongoing sort.
+ *
+ * @param a the array to be sorted
+ * @param c the comparator to determine the order of the sort
+ */
+func newTimSortI(a []int, lt IntLessThan) (hi *timSortHandlerI) {
+	hi = &timSortHandlerI{
+		a:         a,
+		lt:        lt,
+		minGallop: minGallop}
+
+	// Allocate temp storage (which may be increased later if necessary)
+	len := len(a)
+
+	tmpSize := initialTmpStorageLength
+	if len < 2*tmpSize {
+		tmpSize = len / 2
+	}
+
+	hi.tmp = make([]int, tmpSize)
+
+	/*
+	 * Allocate runs-to-be-merged stack (which cannot be expanded).  The
+	 * stack length requirements are described in listsort.txt.  The C
+	 * version always uses the same stack length (85), but this was
+	 * measured to be too expensive when sorting "mid-sized" arrays (e.g.,
+	 * 100 elements) in Java.  Therefore, we use smaller (but sufficiently
+	 * large) stack lengths for smaller arrays.  The "magic numbers" in the
+	 * computation below must be changed if c_MIN_MERGE is decreased.  See
+	 * the c_MIN_MERGE declaration above for more information.
+	 */
+	// mk: confirmed that for small sorts this optimization gives measurable (albeit small)
+	// performance enhancement
+	stackLen := 40
+	if len < 120 {
+		stackLen = 5
+	} else if len < 1542 {
+		stackLen = 10
+	} else if len < 119151 {
+		stackLen = 19
+	}
+
+	hi.runBase = make([]int, stackLen)
+	hi.runLen = make([]int, stackLen)
+
+	return hi
+}
+
+// Ints sorts an interger array using the provided comparator
+func Ints(a []int, lt IntLessThan) {
+	lo := 0
+	hi := len(a)
+	nRemaining := hi
+
+	if nRemaining < 2 {
+		return // Arrays of size 0 and 1 are always sorted
+	}
+
+	// If array is small, do a "mini-TimSort" with no merges
+	if nRemaining < minMerge {
+		initRunLen := countRunAndMakeAscendingI(a, lo, hi, lt)
+
+		binarySortI(a, lo, hi, lo+initRunLen, lt)
+		return
+	}
+
+	/**
+	 * March over the array once, left to right, finding natural runs,
+	 * extending short natural runs to minRun elements, and merging runs
+	 * to maintain stack invariant.
+	 */
+
+	ts := newTimSortI(a, lt)
+	minRun := minRunLength(nRemaining)
+
+	for {
+		// Identify next run
+		runLen := countRunAndMakeAscendingI(a, lo, hi, lt)
+
+		// If run is short, extend to min(minRun, nRemaining)
+		if runLen < minRun {
+			force := minRun
+			if nRemaining <= minRun {
+				force = nRemaining
+			}
+			binarySortI(a, lo, lo+force, lo+runLen, lt)
+			runLen = force
+		}
+
+		// Push run onto pending-run stack, and maybe merge
+		ts.pushRun(lo, runLen)
+		ts.mergeCollapse()
+
+		// Advance to find next run
+		lo += runLen
+		nRemaining -= runLen
+		if nRemaining == 0 {
+			break
+		}
+	}
+
+	ts.mergeForceCollapse()
+
+}
+
+/**
+ * Sorts the specified portion of the specified array using a binary
+ * insertion sort.  This is the best method for sorting small numbers
+ * of elements.  It requires O(n log n) compares, but O(n^2) data
+ * movement (worst case).
+ *
+ * If the initial part of the specified range is already sorted,
+ * this method can take advantage of it: the method assumes that the
+ * elements from index {@code lo}, inclusive, to {@code start},
+ * exclusive are already sorted.
+ *
+ * @param a the array in which a range is to be sorted
+ * @param lo the index of the first element in the range to be sorted
+ * @param hi the index after the last element in the range to be sorted
+ * @param start the index of the first element in the range that is
+ *        not already known to be sorted (@code lo <= start <= hi}
+ * @param c comparator to used for the sort
+ */
+func binarySortI(a []int, lo, hi, start int, lt IntLessThan) {
+	if start == lo {
+		start++
+	}
+
+	for ; start < hi; start++ {
+		pivot := a[start]
+
+		// Set left (and right) to the index where a[start] (pivot) belongs
+		left := lo
+		right := start
+
+		/*
+		 * Invariants:
+		 *   pivot >= all in [lo, left).
+		 *   pivot <  all in [right, start).
+		 */
+		for left < right {
+			mid := int(uint(left+right) >> 1)
+			if lt(pivot, a[mid]) {
+				right = mid
+			} else {
+				left = mid + 1
+			}
+		}
+
+		/*
+		 * The invariants still hold: pivot >= all in [lo, left) and
+		 * pivot < all in [left, start), so pivot belongs at left.  Note
+		 * that if there are elements equal to pivot, left points to the
+		 * first slot after them -- that's why this sort is stable.
+		 * Slide elements over to make room to make room for pivot.
+		 */
+		n := start - left // The number of elements to move
+		// just an optimization for copy in default case
+		if n <= 2 {
+			if n == 2 {
+				a[left+2] = a[left+1]
+			}
+			if n > 0 {
+				a[left+1] = a[left]
+			}
+		} else {
+			copy(a[left+1:], a[left:left+n])
+		}
+		a[left] = pivot
+	}
+}
+
+/**
+  * Returns the length of the run beginning at the specified position in
+  * the specified array and reverses the run if it is descending (ensuring
+  * that the run will always be ascending when the method returns).
+  *
+  * A run is the longest ascending sequence with:
+  *
+  *    a[lo] <= a[lo + 1] <= a[lo + 2] <= ...
+  *
+  * or the longest descending sequence with:
+  *
+  *    a[lo] >  a[lo + 1] >  a[lo + 2] >  ...
+  *
+  * For its intended use in a stable mergesort, the strictness of the
+  * definition of "descending" is needed so that the call can safely
+  * reverse a descending sequence without violating stability.
+  *
+  * @param a the array in which a run is to be counted and possibly reversed
+  * @param lo index of the first element in the run
+  * @param hi index after the last element that may be contained in the run.
+           It is required that @code{lo < hi}.
+  * @param c the comparator to used for the sort
+  * @return  the length of the run beginning at the specified position in
+  *          the specified array
+*/
+func countRunAndMakeAscendingI(a []int, lo, hi int, lt IntLessThan) int {
+	runHi := lo + 1
+	if runHi == hi {
+		return 1
+	}
+
+	// Find end of run, and reverse range if descending
+	if lt(a[runHi], a[lo]) { // Descending
+		runHi++
+
+		for runHi < hi && lt(a[runHi], a[runHi-1]) {
+			runHi++
+		}
+		reverseRangeI(a, lo, runHi)
+	} else { // Ascending
+		for runHi < hi && !lt(a[runHi], a[runHi-1]) {
+			runHi++
+		}
+	}
+
+	return runHi - lo
+}
+
+/**
+ * Reverse the specified range of the specified array.
+ *
+ * @param a the array in which a range is to be reversed
+ * @param lo the index of the first element in the range to be reversed
+ * @param hi the index after the last element in the range to be reversed
+ */
+func reverseRangeI(a []int, lo, hi int) {
+	hi--
+	for lo < hi {
+		a[lo], a[hi] = a[hi], a[lo]
+		lo++
+		hi--
+	}
+}
+
+/**
+ * Pushes the specified run onto the pending-run stack.
+ *
+ * @param runBase index of the first element in the run
+ * @param runLen  the number of elements in the run
+ */
+func (hi *timSortHandlerI) pushRun(runBase, runLen int) {
+	hi.runBase[hi.stackSize] = runBase
+	hi.runLen[hi.stackSize] = runLen
+	hi.stackSize++
+}
+
+/**
+ * Examines the stack of runs waiting to be merged and merges adjacent runs
+ * until the stack invariants are reestablished:
+ *
+ *     1. runLen[i - 3] > runLen[i - 2] + runLen[i - 1]
+ *     2. runLen[i - 2] > runLen[i - 1]
+ *
+ * This method is called each time a new run is pushed onto the stack,
+ * so the invariants are guaranteed to hold for i < stackSize upon
+ * entry to the method.
+ */
+func (hi *timSortHandlerI) mergeCollapse() {
+	for hi.stackSize > 1 {
+		n := hi.stackSize - 2
+		if (n > 0 && hi.runLen[n-1] <= hi.runLen[n]+hi.runLen[n+1]) ||
+			(n > 1 && hi.runLen[n-2] <= hi.runLen[n-1]+hi.runLen[n]) {
+			if hi.runLen[n-1] < hi.runLen[n+1] {
+				n--
+			}
+			hi.mergeAt(n)
+		} else if hi.runLen[n] <= hi.runLen[n+1] {
+			hi.mergeAt(n)
+		} else {
+			break // Invariant is established
+		}
+	}
+}
+
+/**
+ * Merges all runs on the stack until only one remains.  This method is
+ * called once, to complete the sort.
+ */
+func (hi *timSortHandlerI) mergeForceCollapse() {
+	for hi.stackSize > 1 {
+		n := hi.stackSize - 2
+		if n > 0 && hi.runLen[n-1] < hi.runLen[n+1] {
+			n--
+		}
+		hi.mergeAt(n)
+	}
+}
+
+/**
+ * Merges the two runs at stack indices i and i+1.  Run i must be
+ * the penultimate or antepenultimate run on the stack.  In other words,
+ * i must be equal to stackSize-2 or stackSize-3.
+ *
+ * @param i stack index of the first of the two runs to merge
+ */
+func (hi *timSortHandlerI) mergeAt(i int) {
+	base1 := hi.runBase[i]
+	len1 := hi.runLen[i]
+	base2 := hi.runBase[i+1]
+	len2 := hi.runLen[i+1]
+
+	/*
+	 * Record the length of the combined runs; if i is the 3rd-last
+	 * run now, also slide over the last run (which isn't involved
+	 * in this merge).  The current run (i+1) goes away in any case.
+	 */
+	hi.runLen[i] = len1 + len2
+	if i == hi.stackSize-3 {
+		hi.runBase[i+1] = hi.runBase[i+2]
+		hi.runLen[i+1] = hi.runLen[i+2]
+	}
+	hi.stackSize--
+
+	/*
+	 * Find where the first element of run2 goes in run1. Prior elements
+	 * in run1 can be ignored (because they're already in place).
+	 */
+	k := gallopRightI(hi.a[base2], hi.a, base1, len1, 0, hi.lt)
+	base1 += k
+	len1 -= k
+	if len1 == 0 {
+		return
+	}
+
+	/*
+	 * Find where the last element of run1 goes in run2. Subsequent elements
+	 * in run2 can be ignored (because they're already in place).
+	 */
+	len2 = gallopLeftI(hi.a[base1+len1-1], hi.a, base2, len2, len2-1, hi.lt)
+	if len2 == 0 {
+		return
+	}
+
+	// Merge remaining runs, using tmp array with min(len1, len2) elements
+	if len1 <= len2 {
+		hi.mergeLo(base1, len1, base2, len2)
+	} else {
+		hi.mergeHi(base1, len1, base2, len2)
+	}
+}
+
+/**
+ * Locates the position at which to insert the specified key into the
+ * specified sorted range; if the range contains an element equal to key,
+ * returns the index of the leftmost equal element.
+ *
+ * @param key the key whose insertion point to search for
+ * @param a the array in which to search
+ * @param base the index of the first element in the range
+ * @param len the length of the range; must be > 0
+ * @param hint the index at which to begin the search, 0 <= hint < n.
+ *     The closer hint is to the result, the faster this method will run.
+ * @param c the comparator used to order the range, and to search
+ * @return the int k,  0 <= k <= n such that a[b + k - 1] < key <= a[b + k],
+ *    pretending that a[b - 1] is minus infinity and a[b + n] is infinity.
+ *    In other words, key belongs at index b + k; or in other words,
+ *    the first k elements of a should precede key, and the last n - k
+ *    should follow it.
+ */
+func gallopLeftI(key int, a []int, base, len, hint int, c IntLessThan) int {
+	lastOfs := 0
+	ofs := 1
+
+	if c(a[base+hint], key) {
+		// Gallop right until a[base+hint+lastOfs] < key <= a[base+hint+ofs]
+		maxOfs := len - hint
+		for ofs < maxOfs && c(a[base+hint+ofs], key) {
+			lastOfs = ofs
+			ofs = (ofs << 1) + 1
+			if ofs <= 0 { // int overflow
+				ofs = maxOfs
+			}
+		}
+		if ofs > maxOfs {
+			ofs = maxOfs
+		}
+
+		// Make offsets relative to base
+		lastOfs += hint
+		ofs += hint
+	} else { // key <= a[base + hint]
+		// Gallop left until a[base+hint-ofs] < key <= a[base+hint-lastOfs]
+		maxOfs := hint + 1
+		for ofs < maxOfs && !c(a[base+hint-ofs], key) {
+			lastOfs = ofs
+			ofs = (ofs << 1) + 1
+			if ofs <= 0 { // int overflow
+				ofs = maxOfs
+			}
+		}
+		if ofs > maxOfs {
+			ofs = maxOfs
+		}
+
+		// Make offsets relative to base
+		tmp := lastOfs
+		lastOfs = hint - ofs
+		ofs = hint - tmp
+	}
+
+	/*
+	 * Now a[base+lastOfs] < key <= a[base+ofs], so key belongs somewhere
+	 * to the right of lastOfs but no farther right than ofs.  Do a binary
+	 * search, with invariant a[base + lastOfs - 1] < key <= a[base + ofs].
+	 */
+	lastOfs++
+	for lastOfs < ofs {
+		m := lastOfs + (ofs-lastOfs)/2
+
+		if c(a[base+m], key) {
+			lastOfs = m + 1 // a[base + m] < key
+		} else {
+			ofs = m // key <= a[base + m]
+		}
+	}
+
+	return ofs
+}
+
+/**
+ * Like gallopLeft, except that if the range contains an element equal to
+ * key, gallopRight returns the index after the rightmost equal element.
+ *
+ * @param key the key whose insertion point to search for
+ * @param a the array in which to search
+ * @param base the index of the first element in the range
+ * @param len the length of the range; must be > 0
+ * @param hint the index at which to begin the search, 0 <= hint < n.
+ *     The closer hint is to the result, the faster this method will run.
+ * @param c the comparator used to order the range, and to search
+ * @return the int k,  0 <= k <= n such that a[b + k - 1] <= key < a[b + k]
+ */
+func gallopRightI(key int, a []int, base, len, hint int, c IntLessThan) int {
+	ofs := 1
+	lastOfs := 0
+	if c(key, a[base+hint]) {
+		// Gallop left until a[b+hint - ofs] <= key < a[b+hint - lastOfs]
+		maxOfs := hint + 1
+		for ofs < maxOfs && c(key, a[base+hint-ofs]) {
+			lastOfs = ofs
+			ofs = (ofs << 1) + 1
+			if ofs <= 0 { // int overflow
+				ofs = maxOfs
+			}
+		}
+		if ofs > maxOfs {
+			ofs = maxOfs
+		}
+
+		// Make offsets relative to b
+		tmp := lastOfs
+		lastOfs = hint - ofs
+		ofs = hint - tmp
+	} else { // a[b + hint] <= key
+		// Gallop right until a[b+hint + lastOfs] <= key < a[b+hint + ofs]
+		maxOfs := len - hint
+		for ofs < maxOfs && !c(key, a[base+hint+ofs]) {
+			lastOfs = ofs
+			ofs = (ofs << 1) + 1
+			if ofs <= 0 { // int overflow
+				ofs = maxOfs
+			}
+		}
+		if ofs > maxOfs {
+			ofs = maxOfs
+		}
+
+		// Make offsets relative to b
+		lastOfs += hint
+		ofs += hint
+	}
+
+	/*
+	 * Now a[b + lastOfs] <= key < a[b + ofs], so key belongs somewhere to
+	 * the right of lastOfs but no farther right than ofs.  Do a binary
+	 * search, with invariant a[b + lastOfs - 1] <= key < a[b + ofs].
+	 */
+	lastOfs++
+	for lastOfs < ofs {
+		m := lastOfs + (ofs-lastOfs)/2
+
+		if c(key, a[base+m]) {
+			ofs = m // key < a[b + m]
+		} else {
+			lastOfs = m + 1 // a[b + m] <= key
+		}
+	}
+
+	return ofs
+}
+
+/**
+ * Merges two adjacent runs in place, in a stable fashion.  The first
+ * element of the first run must be greater than the first element of the
+ * second run (a[base1] > a[base2]), and the last element of the first run
+ * (a[base1 + len1-1]) must be greater than all elements of the second run.
+ *
+ * For performance, this method should be called only when len1 <= len2;
+ * its twin, mergeHi should be called if len1 >= len2.  (Either method
+ * may be called if len1 == len2.)
+ *
+ * @param base1 index of first element in first run to be merged
+ * @param len1  length of first run to be merged (must be > 0)
+ * @param base2 index of first element in second run to be merged
+ *        (must be aBase + aLen)
+ * @param len2  length of second run to be merged (must be > 0)
+ */
+func (hi *timSortHandlerI) mergeLo(base1, len1, base2, len2 int) {
+	// Copy first run into temp array
+	a := hi.a // For performance
+	tmp := hi.ensureCapacity(len1)
+
+	copy(tmp, a[base1:base1+len1])
+
+	cursor1 := 0     // Indexes into tmp array
+	cursor2 := base2 // Indexes int a
+	dest := base1    // Indexes int a
+
+	// Move first element of second run and deal with degenerate cases
+	a[dest] = a[cursor2]
+	dest++
+	cursor2++
+	len2--
+	if len2 == 0 {
+		copy(a[dest:dest+len1], tmp)
+		return
+	}
+	if len1 == 1 {
+		copy(a[dest:dest+len2], a[cursor2:cursor2+len2])
+		a[dest+len2] = tmp[cursor1] // Last elt of run 1 to end of merge
+		return
+	}
+
+	lt := hi.lt               // Use local variable for performance
+	minGallop := hi.minGallop //  "    "       "     "      "
+
+outer:
+	for {
+		count1 := 0 // Number of times in a row that first run won
+		count2 := 0 // Number of times in a row that second run won
+
+		/*
+		 * Do the straightforward thing until (if ever) one run starts
+		 * winning consistently.
+		 */
+		for {
+			if lt(a[cursor2], tmp[cursor1]) {
+				a[dest] = a[cursor2]
+				dest++
+				cursor2++
+				count2++
+				count1 = 0
+				len2--
+				if len2 == 0 {
+					break outer
+				}
+			} else {
+				a[dest] = tmp[cursor1]
+				dest++
+				cursor1++
+				count1++
+				count2 = 0
+				len1--
+				if len1 == 1 {
+					break outer
+				}
+			}
+			if (count1 | count2) >= minGallop {
+				break
+			}
+		}
+
+		/*
+		 * One run is winning so consistently that galloping may be a
+		 * huge win. So try that, and continue galloping until (if ever)
+		 * neither run appears to be winning consistently anymore.
+		 */
+		for {
+			count1 = gallopRightI(a[cursor2], tmp, cursor1, len1, 0, lt)
+			if count1 != 0 {
+				copy(a[dest:dest+count1], tmp[cursor1:cursor1+count1])
+				dest += count1
+				cursor1 += count1
+				len1 -= count1
+				if len1 <= 1 { // len1 == 1 || len1 == 0
+					break outer
+				}
+			}
+			a[dest] = a[cursor2]
+			dest++
+			cursor2++
+			len2--
+			if len2 == 0 {
+				break outer
+			}
+
+			count2 = gallopLeftI(tmp[cursor1], a, cursor2, len2, 0, lt)
+			if count2 != 0 {
+				copy(a[dest:dest+count2], a[cursor2:cursor2+count2])
+				dest += count2
+				cursor2 += count2
+				len2 -= count2
+				if len2 == 0 {
+					break outer
+				}
+			}
+			a[dest] = tmp[cursor1]
+			dest++
+			cursor1++
+			len1--
+			if len1 == 1 {
+				break outer
+			}
+			minGallop--
+			if count1 < minGallop && count2 < minGallop {
+				break
+			}
+		}
+		if minGallop < 0 {
+			minGallop = 0
+		}
+		minGallop += 2 // Penalize for leaving gallop mode
+	} // End of "outer" loop
+
+	if minGallop < 1 {
+		minGallop = 1
+	}
+	hi.minGallop = minGallop // Write back to field
+
+	if len1 == 1 {
+		copy(a[dest:dest+len2], a[cursor2:cursor2+len2])
+		a[dest+len2] = tmp[cursor1] //  Last elt of run 1 to end of merge
+	} else {
+		copy(a[dest:dest+len1], tmp[cursor1:cursor1+len1])
+	}
+}
+
+/**
+ * Like mergeLo, except that this method should be called only if
+ * len1 >= len2; mergeLo should be called if len1 <= len2.  (Either method
+ * may be called if len1 == len2.)
+ *
+ * @param base1 index of first element in first run to be merged
+ * @param len1  length of first run to be merged (must be > 0)
+ * @param base2 index of first element in second run to be merged
+ *        (must be aBase + aLen)
+ * @param len2  length of second run to be merged (must be > 0)
+ */
+func (hi *timSortHandlerI) mergeHi(base1, len1, base2, len2 int) {
+	// Copy second run into temp array
+	a := hi.a // For performance
+	tmp := hi.ensureCapacity(len2)
+
+	copy(tmp, a[base2:base2+len2])
+
+	cursor1 := base1 + len1 - 1 // Indexes into a
+	cursor2 := len2 - 1         // Indexes into tmp array
+	dest := base2 + len2 - 1    // Indexes into a
+
+	// Move last element of first run and deal with degenerate cases
+	a[dest] = a[cursor1]
+	dest--
+	cursor1--
+	len1--
+	if len1 == 0 {
+		dest -= len2 - 1
+		copy(a[dest:dest+len2], tmp)
+		return
+	}
+	if len2 == 1 {
+		dest -= len1 - 1
+		cursor1 -= len1 - 1
+		copy(a[dest:dest+len1], a[cursor1:cursor1+len1])
+		a[dest-1] = tmp[cursor2]
+		return
+	}
+
+	lt := hi.lt               // Use local variable for performance
+	minGallop := hi.minGallop //  "    "       "     "      "
+
+outer:
+	for {
+		count1 := 0 // Number of times in a row that first run won
+		count2 := 0 // Number of times in a row that second run won
+
+		/*
+		 * Do the straightforward thing until (if ever) one run
+		 * appears to win consistently.
+		 */
+		for {
+			if lt(tmp[cursor2], a[cursor1]) {
+				a[dest] = a[cursor1]
+				dest--
+				cursor1--
+				count1++
+				count2 = 0
+				len1--
+				if len1 == 0 {
+					break outer
+				}
+			} else {
+				a[dest] = tmp[cursor2]
+				dest--
+				cursor2--
+				count2++
+				count1 = 0
+				len2--
+				if len2 == 1 {
+					break outer
+				}
+			}
+			if (count1 | count2) >= minGallop {
+				break
+			}
+		}
+
+		/*
+		 * One run is winning so consistently that galloping may be a
+		 * huge win. So try that, and continue galloping until (if ever)
+		 * neither run appears to be winning consistently anymore.
+		 */
+		for {
+			gr := gallopRightI(tmp[cursor2], a, base1, len1, len1-1, lt)
+			count1 = len1 - gr
+			if count1 != 0 {
+				dest -= count1
+				cursor1 -= count1
+				len1 -= count1
+				copy(a[dest+1:dest+1+count1], a[cursor1+1:cursor1+1+count1])
+				if len1 == 0 {
+					break outer
+				}
+			}
+			a[dest] = tmp[cursor2]
+			dest--
+			cursor2--
+			len2--
+			if len2 == 1 {
+				break outer
+			}
+
+			gl := gallopLeftI(a[cursor1], tmp, 0, len2, len2-1, lt)
+			count2 = len2 - gl
+			if count2 != 0 {
+				dest -= count2
+				cursor2 -= count2
+				len2 -= count2
+				copy(a[dest+1:dest+1+count2], tmp[cursor2+1:cursor2+1+count2])
+				if len2 <= 1 { // len2 == 1 || len2 == 0
+					break outer
+				}
+			}
+			a[dest] = a[cursor1]
+			dest--
+			cursor1--
+			len1--
+			if len1 == 0 {
+				break outer
+			}
+			minGallop--
+
+			if count1 < minGallop && count2 < minGallop {
+				break
+			}
+		}
+		if minGallop < 0 {
+			minGallop = 0
+		}
+		minGallop += 2 // Penalize for leaving gallop mode
+	} // End of "outer" loop
+
+	if minGallop < 1 {
+		minGallop = 1
+	}
+
+	hi.minGallop = minGallop // Write back to field
+
+	if len2 == 1 {
+		dest -= len1
+		cursor1 -= len1
+
+		copy(a[dest+1:dest+1+len1], a[cursor1+1:cursor1+1+len1])
+		a[dest] = tmp[cursor2] // Move first elt of run2 to front of merge
+	} else {
+		copy(a[dest-(len2-1):dest+1], tmp)
+	}
+}
+
+/**
+ * Ensures that the external array tmp has at least the specified
+ * number of elements, increasing its size if necessary.  The size
+ * increases exponentially to ensure amortized linear time complexity.
+ *
+ * @param minCapacity the minimum required capacity of the tmp array
+ * @return tmp, whether or not it grew
+ */
+func (hi *timSortHandlerI) ensureCapacity(minCapacity int) []int {
+	if len(hi.tmp) < minCapacity {
+		// Compute smallest power of 2 > minCapacity
+		newSize := minCapacity
+		newSize |= newSize >> 1
+		newSize |= newSize >> 2
+		newSize |= newSize >> 4
+		newSize |= newSize >> 8
+		newSize |= newSize >> 16
+		newSize++
+
+		if newSize < 0 { // Not bloody likely!
+			newSize = minCapacity
+		} else {
+			ns := len(hi.a) / 2
+			if ns < newSize {
+				newSize = ns
+			}
+		}
+
+		hi.tmp = make([]int, newSize)
+	}
+
+	return hi.tmp
+}

--- a/v3/timsortint_test.go
+++ b/v3/timsortint_test.go
@@ -1,0 +1,118 @@
+package timsort
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func makeTestArrayI(size int) []int {
+	a := make([]int, size)
+
+	for i := 0; i < size; i++ {
+		a[i] = i & 0xeeeeee
+	}
+
+	return a
+}
+
+func IsSortedI(a []int, lessThan IntLessThan) bool {
+	len := len(a)
+
+	if len < 2 {
+		return true
+	}
+
+	prev := a[0]
+	for i := 1; i < len; i++ {
+		if lessThan(a[i], prev) {
+			fmt.Println("false")
+			return false
+		}
+	}
+
+	return true
+}
+
+// use this comparator for sorting
+func intLessThan(a, b int) bool {
+	return a < b
+}
+
+func TestSmokeI(t *testing.T) {
+	a := []int{3, 1, 2}
+
+	Ints(a, intLessThan)
+
+	if !IsSortedI(a, intLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test0I(t *testing.T) {
+	a := makeTestArrayI(1)
+
+	Ints(a, intLessThan)
+	if !IsSortedI(a, intLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test1I(t *testing.T) {
+	a := makeTestArrayI(1)
+
+	Ints(a, intLessThan)
+	if !IsSortedI(a, intLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test1KI(t *testing.T) {
+	a := makeTestArrayI(1024)
+
+	Ints(a, intLessThan)
+	if !IsSortedI(a, intLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test100KI(t *testing.T) {
+	a := makeTestArrayI(100 * 1024)
+
+	Ints(a, intLessThan)
+	if !IsSortedI(a, intLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test1MI(t *testing.T) {
+	a := makeTestArrayI(1024 * 1024)
+
+	Ints(a, intLessThan)
+	if !IsSortedI(a, intLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func makeRandomArrayI(size int) []int {
+	a := make([]int, size)
+
+	for i := 0; i < size; i++ {
+		a[i] = rand.Intn(100)
+	}
+
+	return a
+}
+
+func TestRandom1MI(t *testing.T) {
+	size := 1024 * 1024
+
+	a := makeRandomArrayI(size)
+	b := make([]int, size)
+	copy(b, a)
+
+	Ints(a, intLessThan)
+	if !IsSortedI(a, intLessThan) {
+		t.Error("not sorted")
+	}
+}

--- a/v3/timsortintf.go
+++ b/v3/timsortintf.go
@@ -1,0 +1,28 @@
+package timsort
+
+import (
+	"sort"
+)
+
+// TimSort sorts the data defined by sort.Interface.
+func TimSort(a sort.Interface) {
+	indexes := make([]int, a.Len())
+	for i := 0; i < len(indexes); i++ {
+		indexes[i] = i
+	}
+
+	Ints(indexes, func(i, j int) bool {
+		return a.Less(i, j)
+	})
+
+	for i := 0; i < len(indexes); i++ {
+		j := indexes[i]
+		if j == 0 {
+			continue
+		}
+		for k := i; j != i; {
+			a.Swap(j, k)
+			k, j, indexes[j] = j, indexes[j], 0
+		}
+	}
+}

--- a/v3/timsortintf_test.go
+++ b/v3/timsortintf_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 func TestSmokeTS(t *testing.T) {
-	a := make([]interface{}, 3)
-	a[0] = val{3, 0}
-	a[1] = val{1, 1}
-	a[2] = val{2, 2}
+	a := []val{
+		{3, 0},
+		{1, 1},
+		{2, 2},
+	}
 
 	TimSort(KeyLessThanSlice(a))
 
@@ -21,10 +22,11 @@ func TestSmokeTS(t *testing.T) {
 }
 
 func TestSmokeStabilityTS(t *testing.T) {
-	a := make([]interface{}, 3)
-	a[0] = val{3, 0}
-	a[1] = val{2, 1}
-	a[2] = val{2, 2}
+	a := []val{
+		{3, 0},
+		{2, 1},
+		{2, 2},
+	}
 
 	TimSort(KeyLessThanSlice(a))
 
@@ -55,7 +57,7 @@ func TestRandom1MTS(t *testing.T) {
 	size := 1024 * 1024
 
 	a := makeRandomArray(size)
-	b := make([]interface{}, size)
+	b := make([]val, size)
 	copy(b, a)
 
 	TimSort(KeyLessThanSlice(a))
@@ -77,8 +79,8 @@ func TestBentleyMcIlroyTS(t *testing.T) {
 	sizes := []int{100, 1023, 1024, 1025}
 	dists := []string{"sawtooth", "rand", "stagger", "plateau", "shuffle"}
 	modes := []string{"copy", "reverse", "reverse1", "reverse2", "sort", "dither"}
-	tmp1 := make([]interface{}, 1025*1025)
-	tmp2 := make([]interface{}, 1025*1025)
+	tmp1 := make([]val, 1025*1025)
+	tmp2 := make([]val, 1025*1025)
 	for ni := 0; ni < len(sizes); ni++ {
 		n := sizes[ni]
 		for m := 1; m < 2*n; m *= 2 {
@@ -116,25 +118,25 @@ func TestBentleyMcIlroyTS(t *testing.T) {
 					switch mode {
 					case _Copy:
 						for i := 0; i < n; i++ {
-							mdata[i] = val{data[i].(val).key, i}
+							mdata[i] = val{data[i].key, i}
 						}
 					case _Reverse:
 						for i := 0; i < n; i++ {
-							mdata[i] = val{data[n-i-1].(val).key, i}
+							mdata[i] = val{data[n-i-1].key, i}
 						}
 					case _ReverseFirstHalf:
 						for i := 0; i < n/2; i++ {
-							mdata[i] = val{data[n/2-i-1].(val).key, i}
+							mdata[i] = val{data[n/2-i-1].key, i}
 						}
 						for i := n / 2; i < n; i++ {
-							mdata[i] = val{data[i].(val).key, i}
+							mdata[i] = val{data[i].key, i}
 						}
 					case _ReverseSecondHalf:
 						for i := 0; i < n/2; i++ {
-							mdata[i] = val{data[i].(val).key, i}
+							mdata[i] = val{data[i].key, i}
 						}
 						for i := n / 2; i < n; i++ {
-							mdata[i] = val{data[n-(i-n/2)-1].(val).key, i}
+							mdata[i] = val{data[n-(i-n/2)-1].key, i}
 						}
 					case _Sorted:
 						for i := 0; i < n; i++ {
@@ -145,17 +147,17 @@ func TestBentleyMcIlroyTS(t *testing.T) {
 						Sort(mdata, KeyLessThan)
 					case _Dither:
 						for i := 0; i < n; i++ {
-							mdata[i] = val{data[i].(val).key + i%5, i}
+							mdata[i] = val{data[i].key + i%5, i}
 						}
 					}
 
 					desc := fmt.Sprintf("n=%d m=%d dist=%s mode=%s", n, m, dists[dist], modes[mode])
 
 					for i := 0; i < len(mdata); i++ {
-						mdata[i] = val{mdata[i].(val).key, i}
+						mdata[i] = val{mdata[i].key, i}
 					}
 
-					gdata := make([]interface{}, len(mdata))
+					gdata := make([]val, len(mdata))
 					copy(gdata, mdata)
 
 					TimSort(KeyLessThanSlice(mdata))

--- a/v3/timsortintf_test.go
+++ b/v3/timsortintf_test.go
@@ -1,0 +1,202 @@
+package timsort
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+func TestSmokeTS(t *testing.T) {
+	a := make([]interface{}, 3)
+	a[0] = val{3, 0}
+	a[1] = val{1, 1}
+	a[2] = val{2, 2}
+
+	TimSort(KeyLessThanSlice(a))
+
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func TestSmokeStabilityTS(t *testing.T) {
+	a := make([]interface{}, 3)
+	a[0] = val{3, 0}
+	a[1] = val{2, 1}
+	a[2] = val{2, 2}
+
+	TimSort(KeyLessThanSlice(a))
+
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test1KTS(t *testing.T) {
+	a := makeTestArray(1024)
+
+	TimSort(KeyLessThanSlice(a))
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func Test1MTS(t *testing.T) {
+	a := makeTestArray(1024 * 1024)
+
+	TimSort(KeyLessThanSlice(a))
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+}
+
+func TestRandom1MTS(t *testing.T) {
+	size := 1024 * 1024
+
+	a := makeRandomArray(size)
+	b := make([]interface{}, size)
+	copy(b, a)
+
+	TimSort(KeyLessThanSlice(a))
+	if !IsSorted(a, KeyOrderLessThan) {
+		t.Error("not sorted")
+	}
+
+	// sort by order
+	TimSort(OrderLessThanSlice(a))
+	for i := 0; i < len(b); i++ {
+		if !Equals(b[i], a[i]) {
+			t.Error("oops")
+		}
+	}
+}
+
+func TestBentleyMcIlroyTS(t *testing.T) {
+	//	sizes := []int{100, 1023, 1024, 1025, 1023 * 1023, 1024 * 1024, 1025 * 1025}
+	sizes := []int{100, 1023, 1024, 1025}
+	dists := []string{"sawtooth", "rand", "stagger", "plateau", "shuffle"}
+	modes := []string{"copy", "reverse", "reverse1", "reverse2", "sort", "dither"}
+	tmp1 := make([]interface{}, 1025*1025)
+	tmp2 := make([]interface{}, 1025*1025)
+	for ni := 0; ni < len(sizes); ni++ {
+		n := sizes[ni]
+		for m := 1; m < 2*n; m *= 2 {
+			for dist := 0; dist < _NDist; dist++ {
+				j := 0
+				k := 1
+				data := tmp1[0:n]
+				for i := 0; i < n; i++ {
+					switch dist {
+					case _Sawtooth:
+						data[i] = val{i % m, i}
+					case _Rand:
+						data[i] = val{rand.Intn(m), i}
+					case _Stagger:
+						data[i] = val{(i*m + i) % n, i}
+					case _Plateau:
+						if i < m {
+							data[i] = val{i, i}
+						} else {
+							data[i] = val{m, i}
+						}
+					case _Shuffle:
+						if rand.Intn(m) != 0 {
+							j += 2
+							data[i] = val{j, i}
+						} else {
+							k += 2
+							data[i] = val{k, i}
+						}
+					}
+				}
+
+				mdata := tmp2[0:n]
+				for mode := 0; mode < _NMode; mode++ {
+					switch mode {
+					case _Copy:
+						for i := 0; i < n; i++ {
+							mdata[i] = val{data[i].(val).key, i}
+						}
+					case _Reverse:
+						for i := 0; i < n; i++ {
+							mdata[i] = val{data[n-i-1].(val).key, i}
+						}
+					case _ReverseFirstHalf:
+						for i := 0; i < n/2; i++ {
+							mdata[i] = val{data[n/2-i-1].(val).key, i}
+						}
+						for i := n / 2; i < n; i++ {
+							mdata[i] = val{data[i].(val).key, i}
+						}
+					case _ReverseSecondHalf:
+						for i := 0; i < n/2; i++ {
+							mdata[i] = val{data[i].(val).key, i}
+						}
+						for i := n / 2; i < n; i++ {
+							mdata[i] = val{data[n-(i-n/2)-1].(val).key, i}
+						}
+					case _Sorted:
+						for i := 0; i < n; i++ {
+							mdata[i] = data[i]
+						}
+						// SortInts is known to be correct
+						// because mode Sort runs after mode _Copy.
+						Sort(mdata, KeyLessThan)
+					case _Dither:
+						for i := 0; i < n; i++ {
+							mdata[i] = val{data[i].(val).key + i%5, i}
+						}
+					}
+
+					desc := fmt.Sprintf("n=%d m=%d dist=%s mode=%s", n, m, dists[dist], modes[mode])
+
+					for i := 0; i < len(mdata); i++ {
+						mdata[i] = val{mdata[i].(val).key, i}
+					}
+
+					gdata := make([]interface{}, len(mdata))
+					copy(gdata, mdata)
+
+					TimSort(KeyLessThanSlice(mdata))
+
+					// If we were testing C qsort, we'd have to make a copy
+					// of the array and sort it ourselves and then compare
+					// x against it, to ensure that qsort was only permuting
+					// the data, not (for example) overwriting it with zeros.
+					//
+					// In go, we don't have to be so paranoid: since the only
+					// mutating method Sort can call is TestingData.swap,
+					// it suffices here just to check that the final array is sorted.
+					if !IsSorted(mdata, KeyOrderLessThan) {
+						t.Errorf("%s: ints not sorted", desc)
+						t.Errorf("\t%v", mdata)
+						t.FailNow()
+					}
+
+					TimSort(OrderLessThanSlice(mdata))
+					for i := 0; i < len(data); i++ {
+						if !Equals(gdata[i], mdata[i]) {
+							t.Error("restore sort failed")
+							t.Errorf("gdata=%v", gdata)
+							t.Errorf("mdata=%v", mdata)
+							t.Errorf("bad index: %v\n", i)
+							t.FailNow()
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestStrings1TS(t *testing.T) {
+	a := []string{
+		"ef",
+		"abc",
+		"aaa",
+		"de",
+		"ed",
+	}
+	TimSort(sort.StringSlice(a))
+}


### PR DESCRIPTION
Moving to generics to make more type safe and possible faster given the type sorting against.

The changes are in `https://github.com/psilva261/timsort/commit/dcbad9d8eb6ee57292f3b9ac863c01eb3b376d86`

Benchmark diff ( on laptop so result may vary with better cooling)
```bash
goos: linux
goarch: amd64
pkg: github.com/psilva261/timsort/v2
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
                               │  v2/bench.txt  │              v3/bench.txt               │
                               │     sec/op     │     sec/op      vs base                 │
TimsortXor100-20                  2.779µ ±  17%    2.328µ ±  11%   -16.21% (p=0.000 n=10)
TimsortInterXor100-20             4.328µ ±  56%    3.282µ ±   8%         ~ (p=0.089 n=10)
StandardSortXor100-20             3.838µ ±  73%    3.254µ ±  13%   -15.22% (p=0.011 n=10)
TimsortSorted100-20               711.6n ±   9%    823.4n ±  64%   +15.72% (p=0.011 n=10)
TimsortInterSorted100-20          1.105µ ±  42%    1.028µ ±  10%    -6.88% (p=0.019 n=10)
StandardSortSorted100-20          409.9n ±  16%    412.9n ±   4%         ~ (p=0.912 n=10)
TimsortRevSorted100-20            763.7n ±  24%    794.9n ±  45%         ~ (p=0.529 n=10)
TimsortInterRevSorted100-20       1.207µ ±   5%    1.200µ ±  10%         ~ (p=0.725 n=10)
StandardSortRevSorted100-20       4.011µ ±  15%    4.497µ ±  72%         ~ (p=0.052 n=10)
TimsortRandom100-20               3.073µ ±  15%    4.466µ ±  29%   +45.33% (p=0.011 n=10)
TimsortInterRandom100-20          3.468µ ±   8%    3.574µ ±  14%         ~ (p=0.393 n=10)
StandardSortRandom100-20          6.088µ ± 109%    4.745µ ±   7%   -22.06% (p=0.001 n=10)
TimsortXor1K-20                  111.16µ ± 108%    50.79µ ±  23%   -54.31% (p=0.000 n=10)
TimsortInterXor1K-20             142.73µ ± 163%    43.33µ ±  73%   -69.65% (p=0.000 n=10)
StandardSortXor1K-20             140.44µ ±  68%    58.26µ ±  17%   -58.51% (p=0.000 n=10)
TimsortSorted1K-20                6.136µ ±  27%    4.882µ ±  47%         ~ (p=0.143 n=10)
TimsortInterSorted1K-20           12.45µ ±  39%    11.23µ ±  29%         ~ (p=0.481 n=10)
StandardSortSorted1K-20           3.704µ ±  14%    6.704µ ±  24%   +80.98% (p=0.001 n=10)
TimsortRevSorted1K-20             7.290µ ±  15%    5.876µ ±  37%         ~ (p=0.075 n=10)
TimsortInterRevSorted1K-20        15.82µ ± 104%    13.70µ ±  23%   -13.40% (p=0.019 n=10)
StandardSortRevSorted1K-20       132.06µ ± 131%    47.74µ ±  24%   -63.85% (p=0.000 n=10)
TimsortRandom1K-20               117.42µ ±  38%    64.75µ ±  61%   -44.86% (p=0.000 n=10)
TimsortInterRandom1K-20          116.78µ ±  35%    81.27µ ±  55%   -30.41% (p=0.011 n=10)
StandardSortRandom1K-20           119.3µ ±  28%    117.7µ ±  47%         ~ (p=0.796 n=10)
TimsortXor1M-20                   61.92m ±  14%    45.19m ±   5%   -27.02% (p=0.000 n=10)
TimsortInterXor1M-20              63.45m ±   5%    67.81m ±  13%         ~ (p=0.143 n=10)
StandardSortXor1M-20              128.8m ±   7%    127.4m ±   6%         ~ (p=0.631 n=10)
TimsortSorted1M-20                3.182m ±  14%    3.375m ±  47%         ~ (p=0.796 n=10)
TimsortInterSorted1M-20           7.081m ±  52%    5.909m ±  62%         ~ (p=0.165 n=10)
StandardSortSorted1M-20           6.138m ±  39%   12.584m ±  20%  +105.03% (p=0.000 n=10)
TimsortRevSorted1M-20             9.803m ± 131%    6.557m ± 127%         ~ (p=0.075 n=10)
TimsortInterRevSorted1M-20        11.20m ±  14%    10.96m ±  22%         ~ (p=0.579 n=10)
StandardSortRevSorted1M-20        83.70m ±  27%    86.26m ±  32%         ~ (p=0.739 n=10)
TimsortRandom1M-20                228.3m ±  18%    160.1m ±   4%   -29.86% (p=0.000 n=10)
TimsortInterRandom1M-20           275.7m ±  46%    254.2m ±   6%    -7.79% (p=0.019 n=10)
StandardSortRandom1M-20           437.0m ±  49%    433.2m ±  28%         ~ (p=0.529 n=10)
TimsortIXor100-20                 2.590µ ±   8%    2.093µ ±  13%   -19.19% (p=0.000 n=10)
StandardSortIXor100-20            3.357µ ±  54%    1.933µ ±  13%   -42.41% (p=0.000 n=10)
TimsortISorted100-20              925.5n ±  68%    551.6n ±  92%   -40.40% (p=0.005 n=10)
StandardSortISorted100-20         402.9n ±  82%    280.0n ± 150%         ~ (p=0.075 n=10)
TimsortIRevSorted100-20           894.5n ±  19%    542.3n ±   6%   -39.37% (p=0.001 n=10)
StandardSortIRevSorted100-20      578.2n ±  81%    391.6n ±  92%         ~ (p=0.063 n=10)
TimsortIRandom100-20              2.277µ ±  35%    3.735µ ±  62%         ~ (p=0.052 n=10)
StandardSortIRandom100-20         3.437µ ±  34%    2.068µ ±   3%   -39.83% (p=0.000 n=10)
TimsortIXor1K-20                  25.61µ ±  22%    24.90µ ±  31%         ~ (p=0.579 n=10)
StandardSortIXor1K-20             40.79µ ±  24%    45.63µ ±  45%         ~ (p=0.436 n=10)
TimsortISorted1K-20               2.829µ ±  29%    2.992µ ±  21%         ~ (p=1.000 n=10)
StandardSortISorted1K-20          1.872µ ±  13%    2.043µ ±  11%         ~ (p=0.165 n=10)
TimsortIRevSorted1K-20            3.408µ ±  27%    7.423µ ± 111%  +117.84% (p=0.000 n=10)
StandardSortIRevSorted1K-20       6.007µ ±  34%    2.936µ ±  61%   -51.13% (p=0.009 n=10)
TimsortIRandom1K-20              137.42µ ± 231%    47.95µ ±  17%   -65.11% (p=0.000 n=10)
StandardSortIRandom1K-20         140.14µ ± 144%    60.36µ ±   8%   -56.93% (p=0.000 n=10)
TimsortIXor1M-20                  57.35m ±   5%    38.04m ±   7%   -33.68% (p=0.000 n=10)
StandardSortIXor1M-20             68.68m ±  34%    45.04m ±   3%   -34.41% (p=0.001 n=10)
TimsortISorted1M-20               2.359m ±  35%    2.553m ±  30%         ~ (p=0.393 n=10)
StandardSortISorted1M-20          2.754m ±  31%    1.857m ±  40%   -32.56% (p=0.019 n=10)
TimsortIRevSorted1M-20            2.694m ±  53%    2.820m ±  33%         ~ (p=0.971 n=10)
StandardSortIRevSorted1M-20       3.499m ±  51%    4.177m ±  33%         ~ (p=0.529 n=10)
TimsortIRandom1M-20               144.7m ±   4%    160.3m ±  33%   +10.78% (p=0.011 n=10)
StandardSortIRandom1M-20          141.1m ±   3%    150.9m ±   5%    +6.98% (p=0.001 n=10)
TimsortStrXor100-20              10.330µ ±  50%    4.853µ ±  12%   -53.02% (p=0.005 n=10)
StandardSortStrXor100-20          5.594µ ±  42%    4.127µ ±   8%   -26.23% (p=0.011 n=10)
TimsortStrSorted100-20            2.866µ ±  22%    2.988µ ±  13%         ~ (p=0.971 n=10)
StandardSortStrSorted100-20       3.726µ ±   9%    3.758µ ±  17%         ~ (p=0.796 n=10)
TimsortStrRevSorted100-20         3.906µ ±  19%    3.581µ ±  14%         ~ (p=0.247 n=10)
StandardSortStrRevSorted100-20    6.710µ ±  16%    6.691µ ±  18%         ~ (p=0.684 n=10)
TimsortStrRandom100-20            5.507µ ±  11%   11.262µ ±  43%  +104.51% (p=0.000 n=10)
StandardSortStrRandom100-20       4.413µ ±   7%    9.079µ ± 204%  +105.73% (p=0.000 n=10)
TimsortStrXor1K-20                76.02µ ±  14%    89.92µ ±  29%         ~ (p=0.143 n=10)
StandardSortStrXor1K-20           121.3µ ±  10%    128.3µ ±  90%         ~ (p=0.247 n=10)
TimsortStrSorted1K-20             49.30µ ±  44%    36.58µ ±  26%   -25.82% (p=0.043 n=10)
StandardSortStrSorted1K-20        249.3µ ± 122%    102.4µ ±  38%   -58.94% (p=0.000 n=10)
TimsortStrRevSorted1K-20         113.58µ ± 139%    30.65µ ±  13%   -73.01% (p=0.000 n=10)
StandardSortStrRevSorted1K-20    234.42µ ±  72%    99.39µ ±  15%   -57.60% (p=0.000 n=10)
TimsortStrRandom1K-20             185.4µ ±  16%    156.8µ ±  27%   -15.41% (p=0.011 n=10)
StandardSortStrRandom1K-20        180.1µ ±  26%    117.9µ ±  91%         ~ (p=0.075 n=10)
TimsortStrXor1M-20                123.4m ±   6%    123.8m ±   6%         ~ (p=0.796 n=10)
StandardSortStrXor1M-20           94.30m ±   6%    90.55m ±   7%         ~ (p=0.315 n=10)
TimsortStrSorted1M-20             66.28m ±   9%   150.91m ±  41%  +127.69% (p=0.000 n=10)
StandardSortStrSorted1M-20        179.9m ±   4%    185.6m ±  44%         ~ (p=0.052 n=10)
TimsortStrRevSorted1M-20         137.19m ±  36%    68.08m ±  29%   -50.38% (p=0.000 n=10)
StandardSortStrRevSorted1M-20     183.6m ±  48%    183.6m ±   4%         ~ (p=0.481 n=10)
TimsortStrRandom1M-20             451.8m ±  75%    454.9m ±  47%         ~ (p=0.912 n=10)
StandardSortStrRandom1M-20        320.2m ±  44%    291.6m ±  71%         ~ (p=0.247 n=10)
```
